### PR TITLE
Add code of conduct and style guide

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -1,6 +1,6 @@
 # Jsdoom Code of Conduct
 
-The jsdoom code of conduct is based on the [microsoft.github.io code of conduct](https://microsoft.github.io/codeofconduct/).
+The jsdoom code of conduct is based on the [Microsoft Open Source Code of Conduct](https://microsoft.github.io/codeofconduct/).
 
 ### Why does this code of conduct exist?
 

--- a/conduct.md
+++ b/conduct.md
@@ -1,0 +1,53 @@
+# Jsdoom Code of Conduct
+
+The jsdoom code of conduct is based on the [microsoft.github.io code of conduct](https://microsoft.github.io/codeofconduct/).
+
+### Why does this code of conduct exist?
+
+The code of conduct describes the expected behavior of those who participate in jsdoom discussion and development. The code of conduct applies not only to individuals' behavior as it is directly related to jsdoom, but also applies to their behavior in other settings.
+
+The purpose of this code of conduct is primarily to maintain a professional and positive manner of interaction between contributors and, secondarily, to ensure that the project is externally represented by people who act in a respectful and professional way toward others.
+
+### What happens if someone violates the code of conduct?
+
+Those who act in contradiction to this code of conduct will be warned about their behavior. Where applicable, offenders will be asked to apologize or make other reparations. Those who violate the code of conduct in especially heinous ways, who violate it repeatedly, or who refuse to make appropriate reparations for harmful actions may be banned from participating in the project.
+
+Disciplinary or remedial actions will be made at the discretion of maintainers, i.e. those who have write access to the jsdoom git repository. Disciplinary or remedial action may include revoking repository privileges or outright bans, temporary or indefinite. Discipline should be in proportion to an individual's offenses.
+
+### What do I do if someone is acting inappropriately?
+
+Please privately contact the maintainers about behavior which violates the code of conduct so that remedial actions can be taken. At the time of writing, the best way to do this is to send an email to the sole maintainer via sophiek (at) pineapplemachine (dot) com.
+
+### How is appropriate or inappropriate behavior defined?
+
+Appropriate behavior is that which leads to a constructive and professional environment. Inappropriate behavior is that which excludes or hurts others.
+
+Here are some more specific guidelines:
+
+#### Be professional
+
+If you wouldn't do it in a professional setting, then you shouldn't do it here. Be polite and respectful.
+
+#### Be patient
+
+Remember that others may not be fluent in the language in which you are communicating, or may not yet share your level of understanding of the concepts being discussed. Constructively criticize contributions so the software may be the best that it can be, but be mindful that your criticism does not take the form of derision or insults.
+
+#### Be welcoming
+
+It is important that people of any culture, background, or identity feel welcome here. Refrain from using exclusive or offensive language.
+
+#### Examples of exemplary behavior
+
+- ✓ Use welcoming and inclusive language.
+- ✓ Be patient and understanding.
+- ✓ Respect the privacy of others.
+- ✓ Gracefully accept criticism.
+
+#### Examples of unacceptable behavior
+
+- ✗ Do not use derogatory or discriminatory language.
+- ✗ Do not use violent language or issue threats.
+- ✗ Do not share others' personal information. (Don't "dox" them.)
+- ✗ Do not insult or harass others.
+- ✗ Do not post sexually explicit material; this is not the place for it.
+- ✗ Do not feed the trolls. Notify a maintainer instead.

--- a/readme.md
+++ b/readme.md
@@ -87,3 +87,7 @@ may be different depending on your server settings.
 You can also make the web views available by hosting them on a remote
 web server. There is one simple example currently hosted at
 https://pineapplemachine.com/demos/jsdoom/inspect-2018-10-23/web/inspector.html.
+
+## Contributing
+
+Contributions are very welcome! This is a big project and it needs as much help as it can get. Before you contribute to jsdoom, though, please take a few minutes to read through the project's [Code of Conduct](https://github.com/pineapplemachine/jsdoom/blob/master/conduct.md) and [Style Guide](https://github.com/pineapplemachine/jsdoom/blob/master/style.md).

--- a/style.md
+++ b/style.md
@@ -333,9 +333,14 @@ const myAsciiVariableName: number = 0;
 
 Functions, classes, variables, and other named entities should have informative, descriptive names. Names should generally not contain abbreviations.
 
-"HTML" abbreviating "HypertextMarkupLanguage" ot "WAD" abbreviating "WheresAllTheData" is okay but "Idx" abbreviating "Index" or "Err" abbreviating "Error" is not. Please use common sense in judging whether an abbreviation is really necessary, and whether it might make the code more difficult to read.
+"HTML" abbreviating "HypertextMarkupLanguage" or "WAD" abbreviating "WheresAllTheData" is okay and encouraged, but "Idx" abbreviating "Index" or "Err" abbreviating "Error" is not okay. Please use common sense in judging whether an abbreviation is really necessary, and whether it might make the code more difficult to read.
 
-Single-letter identifiers are strictly disallowed with the exception of `x`, `y`, `z`, `w`, `i`, `j`, and `k` where specifically used to describe position or vector components, or `a` and `b` where used as the parameters of a comparator function with a clear purpose.
+Single-letter identifiers are strictly disallowed with the exception
+of `x`, `y`, `z`, `w`, `i`, `j`, and `k` where they are specifically used to
+describe position or vector components,
+`t` where used to name the [interpolant parameter of an interpolation function](https://en.wikipedia.org/wiki/Linear_interpolation),
+or `a`, `b`, `c, etc. where they are used to name the parameters of a function
+with very clear inputs and purpose.
 
 ``` ts
 // [Comment explaining the purpose of my vector class]
@@ -343,6 +348,14 @@ class MyVector {
     x: number;
     y: number;
     z: number;
+}
+```
+
+``` ts
+// Linearly interpolate between the numbers "a" and "b".
+// The value "t" should normally be in the inclusive range [0.0, 1.0].
+function lerp(a: number, b: number, t: number): Vector {
+    return (a * (1 - t)) + (b * t);
 }
 ```
 
@@ -355,7 +368,24 @@ myArray.sort((a: number, b: number) => {
 });
 ```
 
-Do not name loop variables `x` or `i`; use descriptive names for them instead. Prefer identifiers like `vectorIndex` over the less descriptive `index`.
+Except for describing the ordering of color channels, e.g. `RGBA` or `ARGB`, do not abbreviate `red` as `r`, `green` as `g`, `blue` as `b`, or `alpha` as `a`.
+Instead, write out the full names of each color channel.
+
+``` ts
+// [Comment explaining the purpose of my interface]
+// Note that each channel attribute is fully written out and not abbreviated.
+interface MyColorInterface {
+    red: number;
+    green: number;
+    blue: number;
+    alpha: number;
+}
+```
+
+Do not assign loop variables single-character names such as `x` or `i` if
+the value does not literally correspond to a position or to a vector component.
+Use descriptive names for loop variables instead, and prefer more descriptive
+identifiers like `vectorIndex` over less descriptive identifiers like `index`.
 
 ``` ts
 for(let vectorIndex: number = 0; vectorIndex < totalVectors; vectorIndex++){

--- a/style.md
+++ b/style.md
@@ -349,8 +349,10 @@ Single-letter identifiers are strictly disallowed with the exception
 of `x`, `y`, `z`, `w`, `i`, `j`, and `k` where they are specifically used to
 describe position or vector components,
 `t` where used to name the [interpolant parameter of an interpolation function](https://en.wikipedia.org/wiki/Linear_interpolation),
-or `a`, `b`, `c, etc. where they are used to name the parameters of a function
+or `a`, `b`, `c`, etc. where they are used to name the parameters of a function
 with very clear inputs and purpose.
+
+To summarize: Single-character identifiers should be used when it follows a long-standing mathematical convention (`x`, `y`, `t`, etc.), or when used to describe a sequence of parameters where sequential single-character identifiers represent a clear and prevalent naming convention (`a`, `b`, `c`, etc.). Single-character identifiers should not generally be used otherwise.
 
 ``` ts
 // [Comment explaining the purpose of my vector class]

--- a/style.md
+++ b/style.md
@@ -248,7 +248,7 @@ const myLongStringLiteral = (
 );
 ```
 
-## Prefer spaces around arrow function parameters
+## Prefer parentheses around arrow function parameters
 
 In general, the parameter list of an arrow function should always be enclosed within paretheses `()`.
 

--- a/style.md
+++ b/style.md
@@ -169,8 +169,8 @@ Indentation must be in such a way that each line is indented at either the
 same level as the last line, one more level, or one less.
 There should never be a jump of two or more indentation levels between lines.
 
-In general, longer expressions made up of chained function calls should be
-broken across lines by using several shorter statements with intermediate
+Longer expressions made up of chained function calls should be broken across
+multiple lines by using several shorter statements with intermediate
 assignments, or by putting the code inside a pair of paretheses `()` etc.
 on a new, idented line.
 They should _not_ be broken across lines by starting each line with the
@@ -200,8 +200,8 @@ parentheses `()`.
 
 Where an open brace `{`, parenthese `(`, etc. is followed by a corresponding
 closing brace `}`, parenthese `)`, etc. with no code in between, there should
-not generally be any whitespace, comments, or other characters in between
-those open and closing characters.
+not be any whitespace, comments, or other characters in between those open and
+closing characters.
 
 ``` ts
 const myEmptyObject: Object = {};
@@ -253,7 +253,7 @@ Open braces `{` should always be followed by a newline and close braces `}`
 should always be preceded by a newline.
 The code in between corresponding braces should be indented at one level
 further than the lines containing those braces.
-In general, an open brace `{` should not be immediately followed by any
+Normally, an open brace `{` should not be immediately followed by any
 character other than a corresponding closing brace `}` or a newline `\n`.
 
 ``` ts
@@ -266,8 +266,8 @@ const myObject: Object = {
 
 #### <a id="1.4.4."></a> 1.4.4. Do not put open braces on their own line
 
-Open braces `{` generally should _not_ be preceded by a newline.
-Open braces `{` should generally be on the same line as the statement or
+Open braces `{` should _not_ be preceded by a newline.
+Open braces `{` should be on the same line as the statement or
 expression that they are a part of.
 
 #### <a id="1.4.5."></a> 1.4.5. Do not pad code between paretheses or brackets
@@ -375,8 +375,8 @@ in code.
 
 #### <a id="2.4.6."></a> 2.4.6. Line breaks should not occur anywhere not mentioned in 2.4.
 
-In general, line breaks on lines containing code should not occur under
-circumstances other than the ones explicitly mentioned below.
+Line breaks on lines containing code should not occur under circumstances
+other than the ones explicitly mentioned below.
 
 Comments may exceptionally appear in between a character that would normally
 precede a line break and the terminating newline.
@@ -398,9 +398,6 @@ const mySecondDeclaration: number = 2;
 
 Long lists of arguments, parameters, attributes, or other comma-separated
 lists may be broken up by placing newlines after the commas.
-
-In general, either all of the commas in a list should be followed by
-newlines or none of them should be.
 
 ``` ts
 const myMultiLineArray: number[] = [
@@ -465,14 +462,14 @@ The first line in a source file should not be a blank line.
 
 #### <a id="2.2.2."></a> 2.2.2. Functions and methods should be padded by blank lines
 
-In general, function or method declarations should be padded on each side
-by a single blank line, except for where the immediately previous or following
+Function or method declarations should be padded on each side by a single
+blank line, except for where the immediately previous or following
 line is the first line of the class declaration containing a method, or the
 line containing a class declaration's closing brace `}`.
 
 This does _not_ apply to helper functions that are declared inside another
 function. In general, function blocks should not contain blank lines, not
-even to pad helper function declarations.
+even to pad helper function declarations. (See `2.2.3.`.)
 
 ``` ts
 // [Comment explaining the purpose of my function]
@@ -512,8 +509,7 @@ class MyClass {
 
 #### <a id="2.2.3."></a> 2.2.3. Function blocks should not contain blank lines
 
-In general, the implementation of a function or method should not contain
-blank lines.
+The implementation of a function or method should not contain blank lines.
 If a function is made up of several different conceptual units,
 then they should be separated by explanatory comments instead of separated
 by blank lines.
@@ -567,7 +563,7 @@ Block statements such as the body of a loop or an `if` statement should
 always be enclosed within braces, even if it is syntactically valid to
 omit those braces.
 Single-line conditionals or loops without braces around their bodies should
-not generally be used.
+not be used.
 
 ``` ts
 if(myExitCondition){
@@ -606,7 +602,7 @@ as they apply to arrow functions.
 
 #### <a id="3.5.1."></a> 3.5.1. Prefer parentheses around arrow function parameters
 
-In general, the parameter list of an arrow function should always be enclosed
+The parameter list of an arrow function should always be enclosed
 within paretheses `()`, even when there is only a single parameter.
 
 ``` ts
@@ -617,8 +613,8 @@ myArray.map((value) => {
 
 #### <a id="3.5.2."></a> 3.5.2. Prefer braces around arrow function bodies
 
-In general, the bodies of arrow functions should always be enclosed within
-braces `{}`, even when the function body contains only a `return` statement.
+The bodies of arrow functions should always be enclosed within braces `{}`,
+even when the function body contains only a `return` statement.
 
 ``` ts
 myArray.filter((value) => {
@@ -634,7 +630,7 @@ as they apply to string literals.
 #### <a id="3.6.1."></a> 3.6.1. Prefer double-quoted strings
 
 String literals should be double-quoted `""`.
-In general, they should not ever be single-quoted `''`, even when the literal
+String literals should not ever be single-quoted `''`, even when the literal
 itself contains double quotes.
 
 Template strings (enclosed within backticks) should not be used for
@@ -1163,8 +1159,8 @@ import {WADFile} from "@src/wad/file";
 
 Imports should first be ordered by logical group, and then alphabetically by
 filename.
-Groups should generally be ordered from most general to most specialized.
-Here is a guideline for how to separate and order these groups:
+Groups of similar imports should be ordered from most general to most
+specialized. Here is a guideline for how to separate and order these groups:
 
 1. Native dependencies, such as Node.js imports.
 2. External dependencies, i.e. those listed in `package.json`.
@@ -1308,7 +1304,7 @@ is clearly documented.
 
 ### <a id="7.5."></a> 7.5. Class getters should treat the instance as logically const
 
-In general, getters (i.e. methods preceded by the `get` keyword) should treat
+Getter methods (i.e. methods preceded by the `get` keyword) should treat
 the instance `this` as [logically const](http://wiki.c2.com/?LogicalConst).
 Logical const means that the object may technically be modified,
 but any modification that does take place should not affect or be visible to

--- a/style.md
+++ b/style.md
@@ -41,12 +41,13 @@ console.log("jsdoom is pretty neat");
 * [**2.** Newlines](#2-newlines)
     * [**2.1.** Lines should not exceed eighty characters](#21-lines-should-not-exceed-eighty-characters)
     * [**2.4.** Line breaks](#24-line-breaks)
-        * [**2.4.1.** Line breaks should always occur after a semicolon](#241-line-breaks-should-always-occur-after-a-semicolon)
-        * [**2.4.2.** Line breaks may occur after a comma](#242-line-breaks-may-occur-after-a-comma)
-        * [**2.4.3.** Line breaks may occur after an open brace, bracket, or parethese](#243-line-breaks-may-occur-after-an-open-brace-bracket-or-parethese)
-        * [**2.4.4.** Line breaks may occur after an infix operator](#244-line-breaks-may-occur-after-an-infix-operator)
-        * [**2.4.5.** Line breaks may occur after the last expression in a list](#245-line-breaks-may-occur-after-the-last-expression-in-a-list)
-        * [**2.4.6.** Line breaks should not occur anywhere not mentioned in **2.4.**](#246-line-breaks-should-not-occur-anywhere-not-mentioned-in-24)
+        * [**2.4.1.** Line breaks should not occur anywhere not mentioned in **2.4.**](#241-line-breaks-should-not-occur-anywhere-not-mentioned-in-24)
+        * [**2.4.2.** Line breaks should always occur after a semicolon](#242-line-breaks-should-always-occur-after-a-semicolon)
+        * [**2.4.3.** Line breaks may occur after a comma](#243-line-breaks-may-occur-after-a-comma)
+        * [**2.4.4.** Line breaks may occur after an open brace, bracket, or parethese](#244-line-breaks-may-occur-after-an-open-brace-bracket-or-parethese)
+        * [**2.4.5.** Line breaks may occur after an infix operator](#245-line-breaks-may-occur-after-an-infix-operator)
+        * [**2.4.6.** Line breaks may occur after the last expression in a list](#246-line-breaks-may-occur-after-the-last-expression-in-a-list)
+        * [**2.4.7.** Line breaks may occur after either symbol of a ternary expression](#247-line-breaks-may-occur-after-either-symbol-of-a-ternary-expression)
     * [**2.2.** Blank lines](#22-blank-lines)
         * [**2.2.1.** Source files should not begin with a blank line](#221-source-files-should-not-begin-with-a-blank-line)
         * [**2.2.2.** Functions and methods should be padded by blank lines](#222-functions-and-methods-should-be-padded-by-blank-lines)
@@ -89,12 +90,12 @@ console.log("jsdoom is pretty neat");
     * [**5.5.** Functions and variables should have camelCase names](#55-functions-and-variables-should-have-camelcase-names)
     * [**5.6.** TypeScript source files should have camelCase names](#56-typescript-source-files-should-have-camelcase-names)
     * [**5.7.** Single-character names](#57-single-character-names)
-        * [**5.7.1.** Parameters with very clear purpose may be named "a", "b", "c", and so on](#571-parameters-with-very-clear-purpose-may-be-named-a-b-c-and-so-on)
-        * [**5.7.2.** The interpolant parameter should be named "t"](#572-the-interpolant-parameter-should-be-named-t)
-        * [**5.7.3.** Extremely generic type parameters may be named "T"](#573-extremely-generic-type-parameters-may-be-named-t)
-        * [**5.7.4.** Coordinates should be named "x", "y", "z", and "w"](#574-coordinates-should-be-named-x-y-z-and-w)
-        * [**5.7.5.** Vector components should be named "ijk" or "xyzw"](#575-vector-components-should-be-named-ijk-or-xyzw)
-        * [**5.7.6.** Single-character names should not be used except as mentioned in **5.7.**](#576-single-character-names-should-not-be-used-except-as-mentioned-in-57)
+        * [**5.7.1.** Single-character names should not be used except as mentioned in **5.7.**](#571-single-character-names-should-not-be-used-except-as-mentioned-in-57)
+        * [**5.7.2.** Parameters with very clear purpose may be named "a", "b", "c", and so on](#572-parameters-with-very-clear-purpose-may-be-named-a-b-c-and-so-on)
+        * [**5.7.3.** The interpolant parameter should be named "t"](#573-the-interpolant-parameter-should-be-named-t)
+        * [**5.7.4.** Extremely generic type parameters may be named "T"](#574-extremely-generic-type-parameters-may-be-named-t)
+        * [**5.7.5.** Coordinates should be named "x", "y", "z", and "w"](#575-coordinates-should-be-named-x-y-z-and-w)
+        * [**5.7.6.** Vector components should be named "ijk" or "xyzw"](#576-vector-components-should-be-named-ijk-or-xyzw)
 * [**6.** Syntax conventions](#6-syntax-conventions)
     * [**6.1.** Do not use "eval" or the function constructor](#61-do-not-use-eval-or-the-function-constructor)
     * [**6.2.** Do not use "var"](#62-do-not-use-var)
@@ -363,7 +364,18 @@ to be a hard length limit.
 The following guidelines mainly pertain to where line breaks should appear
 in code.
 
-#### 2.4.1. Line breaks should always occur after a semicolon
+#### 2.4.6. Line breaks should not occur anywhere not mentioned in 2.4.
+
+In general, line breaks on lines containing code should not occur under
+circumstances other than the ones explicitly mentioned below.
+
+Comments may exceptionally appear in between a character that would normally
+precede a line break and the terminating newline.
+However, this style of comments is not encouraged.
+In general, comments should appear on their own lines and not at the end
+of a line of code. (See `4.3.`.)
+
+#### 2.4.2. Line breaks should always occur after a semicolon
 
 Semicolons terminating a statement should be immediately followed by a
 newline. Two statements should not appear on the same line.
@@ -373,7 +385,7 @@ const myFirstDeclaration: number = 1;
 const mySecondDeclaration: number = 2;
 ```
 
-#### 2.4.2. Line breaks may occur after a comma
+#### 2.4.3. Line breaks may occur after a comma
 
 Long lists of arguments, parameters, attributes, or other comma-separated
 lists may be broken up by placing newlines after the commas.
@@ -389,12 +401,12 @@ const myMultiLineArray: number[] = [
 ];
 ```
 
-#### 2.4.3. Line breaks may occur after an open brace, bracket, or parethese
+#### 2.4.4. Line breaks may occur after an open brace, bracket, or parethese
 
 The code in between braces, brackets, etc. may appear on separate lines
 and be indented at one additional level.
 
-#### 2.4.4. Line breaks may occur after an infix operator
+#### 2.4.5. Line breaks may occur after an infix operator
 
 It is appropriate for a line break to appear after an infix operator and
 before its right operand.
@@ -406,7 +418,7 @@ const myMultiLineExpression: boolean = (
 );
 ```
 
-#### 2.4.5. Line breaks may occur after the last expression in a list
+#### 2.4.6. Line breaks may occur after the last expression in a list
 
 The last character of a multi-line list should normally be a trailing comma.
 However, in the case that the list appears on one line yet not on the same
@@ -419,16 +431,18 @@ const myValue: number = myMultiLineFunctionInvocation(
 );
 ```
 
-#### 2.4.6. Line breaks should not occur anywhere not mentioned in 2.4.
+#### 2.4.7. Line breaks may occur after either symbol of a ternary expression
 
-In general, line breaks on lines containing code should not occur under
-circumstances other than the ones explicitly mentioned above.
+A line break may immediately follow the first `?` or second `:` symbol of
+a ternary expression, or both, when breaking the expression across several
+lines will improve readability.
 
-Comments may exceptionally appear in between a character that would normally
-precede a line break and the terminating newline.
-However, this style of comments is not encouraged.
-In general, comments should appear on their own lines and not at the end
-of a line of code. (See `4.3.`.)
+``` ts
+const myTernaryExpressionResult: string = (myCondition ?
+    "My first string literal" :
+    "My second string literal"
+);
+```
 
 ### 2.2. Blank lines
 
@@ -891,7 +905,16 @@ The following guidelines mainly pertain to the use of single-character names.
 Single-character names are mostly discouraged, but are still the most
 appropriate naming choice for some cases.
 
-#### 5.7.1. Parameters with very clear purpose may be named "a", "b", "c", and so on
+#### 5.7.1. Single-character names should not be used except as mentioned in 5.7.
+
+Except as otherwise mentioned below in `5.7.`, single-character names should
+not normally be used.
+
+Here is a rule of thumb: Single-character identifiers should only be used when
+it follows a long-standing mathematical or programming convention, such that
+choosing any other name may make the purpose of the variable, etc. less clear.
+
+#### 5.7.2. Parameters with very clear purpose may be named "a", "b", "c", and so on
 
 Sequential single-letter identifiers such as `a`, `b`, `c`, and so on are
 acceptable where they are used to name the parameters of a function with very
@@ -905,7 +928,7 @@ myArray.sort((a: number, b: number) => {
 });
 ```
 
-#### 5.7.2. The interpolant parameter should be named "t"
+#### 5.7.3. The interpolant parameter should be named "t"
 
 Where a parameter or other named value is used as the
 [interpolant parameter of an interpolation function](https://en.wikipedia.org/wiki/Linear_interpolation),
@@ -919,18 +942,18 @@ function lerp(a: number, b: number, t: number): Vector {
 }
 ```
 
-#### 5.7.3. Extremely generic type parameters may be named "T"
+#### 5.7.4. Extremely generic type parameters may be named "T"
 
 A generic function or class accepting a single type parameter may have
 that parameter named `T` if the purpose of the parameter is generic enough
 to not lend itself to a more descriptive name.
 
-#### 5.7.4. Coordinates should be named "x", "y", "z", and "w"
+#### 5.7.5. Coordinates should be named "x", "y", "z", and "w"
 
 The single-character names `x`, `y`, `z`, and `w` are acceptable and encouraged
 when they refer to spatial coordinates along the corresponding axes.
 
-#### 5.7.5. Vector components should be named "ijk" or "xyzw"
+#### 5.7.6. Vector components should be named "ijk" or "xyzw"
 
 The components of vectors or quaternions should normally be named
 either `i`, `j`, `k` or `x`, `y`, `z`, `w`.
@@ -943,15 +966,6 @@ class MyVector {
     z: number;
 }
 ```
-
-#### 5.7.6. Single-character names should not be used except as mentioned in 5.7.
-
-Except as otherwise mentioned above in `5.7.`, single-character names should
-not normally be used.
-
-Here is a rule of thumb: Single-character identifiers should only be used when
-it follows a long-standing mathematical or programming convention, such that
-choosing any other name may make the purpose of the variable, etc. less clear.
 
 
 

--- a/style.md
+++ b/style.md
@@ -105,7 +105,7 @@ const myLongExpressionResult: string = (
 
 ## Always use semicolons
 
-Always put a semicolon `;` at the end of each line. There should not be any whitespace in between the last character on the line and its terminating semicolon.
+Always put a semicolon `;` at the end of each statement. There should not be any whitespace in between the last character on the line and its terminating semicolon.
 
 ``` ts
 doStuff();

--- a/style.md
+++ b/style.md
@@ -13,6 +13,15 @@ Exceptions should be made sparingly, if they are made at all.
 Please [create a GitHub issue](https://github.com/pineapplemachine/jsdoom/issues/new)
 if you would like to request a change or an addition to this style guide.
 
+You can link to a particular guideline in this style guide by using a url
+such as the below example, where the numbers at the end are the same as those at
+the beginning of the header where you wish to link.
+You can also copy the target URL of items in the table of contents.
+
+``` text
+https://github.com/pineapplemachine/jsdoom/blob/master/style.md#user-content-1.4.1.
+```
+
 Throughout this guide, specific examples of conforming code will be provided
 like so:
 
@@ -23,123 +32,123 @@ console.log("jsdoom is pretty neat");
 
 # Table of Contents
 
-* [**1.** Whitespace](#1-whitespace)
-    * [**1.1.** Indent using four spaces](#11-indent-using-four-spaces)
-    * [**1.2.** Do not use double indents](#12-do-not-use-double-indents)
-    * [**1.3.** Do not use partial indents](#13-do-not-use-partial-indents)
-    * [**1.4.** Whitespace as it pertains to braces, brackets, and paretheses](#14-whitespace-as-it-pertains-to-braces-brackets-and-paretheses)
-        * [**1.4.1.** No characters inside empty literals, blocks, or expressions](#141-no-characters-inside-empty-literals-blocks-or-expressions)
-        * [**1.4.2.** Nested code should be indented at one additional level](#142-nested-code-should-be-indented-at-one-additional-level)
-        * [**1.4.3.** Code within braces should not be in-line](#143-code-within-braces-should-not-be-in-line)
-        * [**1.4.4.** Do not put open braces on their own line](#144-do-not-put-open-braces-on-their-own-line)
-        * [**1.4.5.** Do not pad code between paretheses or brackets](#145-do-not-pad-code-between-paretheses-or-brackets)
-    * [**1.5.** Use a single space after colons but no whitespace before](#15-use-a-single-space-after-colons-but-no-whitespace-before)
-    * [**1.5.** Use whitespace after commas but not before](#15-use-whitespace-after-commas-but-not-before)
-    * [**1.6.** Infix operators](#16-infix-operators)
-        * [**1.6.1.** Put a single space between an infix operator and its left operand](#161-put-a-single-space-between-an-infix-operator-and-its-left-operand)
-        * [**1.6.2.** Put whitespace between an infix operator and its right operand](#162-put-whitespace-between-an-infix-operator-and-its-right-operand)
-* [**2.** Newlines](#2-newlines)
-    * [**2.1.** Lines should not exceed eighty characters](#21-lines-should-not-exceed-eighty-characters)
-    * [**2.4.** Line breaks](#24-line-breaks)
-        * [**2.4.1.** Line breaks should not occur anywhere not mentioned in **2.4.**](#241-line-breaks-should-not-occur-anywhere-not-mentioned-in-24)
-        * [**2.4.2.** Line breaks should always occur after a semicolon](#242-line-breaks-should-always-occur-after-a-semicolon)
-        * [**2.4.3.** Line breaks may occur after a comma](#243-line-breaks-may-occur-after-a-comma)
-        * [**2.4.4.** Line breaks may occur after an open brace, bracket, or parethese](#244-line-breaks-may-occur-after-an-open-brace-bracket-or-parethese)
-        * [**2.4.5.** Line breaks may occur after an infix operator](#245-line-breaks-may-occur-after-an-infix-operator)
-        * [**2.4.6.** Line breaks may occur after the last expression in a list](#246-line-breaks-may-occur-after-the-last-expression-in-a-list)
-        * [**2.4.7.** Line breaks may occur after either symbol of a ternary expression](#247-line-breaks-may-occur-after-either-symbol-of-a-ternary-expression)
-    * [**2.2.** Blank lines](#22-blank-lines)
-        * [**2.2.1.** Source files should not begin with a blank line](#221-source-files-should-not-begin-with-a-blank-line)
-        * [**2.2.2.** Functions and methods should be padded by blank lines](#222-functions-and-methods-should-be-padded-by-blank-lines)
-        * [**2.2.3.** Function blocks should not contain blank lines](#223-function-blocks-should-not-contain-blank-lines)
-        * [**2.2.4.** Logical groups of imports should be padded by blank lines](#224-logical-groups-of-imports-should-be-padded-by-blank-lines)
-        * [**2.2.5.** Logical groups of class members should be padded by blank lines](#225-logical-groups-of-class-members-should-be-padded-by-blank-lines)
-    * [**2.5.** There should be a newline at the end of each source file](#25-there-should-be-a-newline-at-the-end-of-each-source-file)
-* [**3.** Punctuation](#3-punctuation)
-    * [**3.1.** Always use semicolons at the end of statements](#31-always-use-semicolons-at-the-end-of-statements)
-    * [**3.2.** Use trailing commas in multi-line lists](#32-use-trailing-commas-in-multi-line-lists)
-    * [**3.3.** Always enclose block statements within braces](#33-always-enclose-block-statements-within-braces)
-    * [**3.4.** Use parentheses generously when mixing infix operators](#34-use-parentheses-generously-when-mixing-infix-operators)
-    * [**3.5.** Arrow functions](#35-arrow-functions)
-        * [**3.5.1.** Prefer parentheses around arrow function parameters](#351-prefer-parentheses-around-arrow-function-parameters)
-        * [**3.5.2.** Prefer braces around arrow function bodies](#352-prefer-braces-around-arrow-function-bodies)
-    * [**3.6.** Strings](#36-strings)
-        * [**3.6.1.** Prefer double-quoted strings](#361-prefer-double-quoted-strings)
-        * [**3.6.2.** Use concatenation when writing long string literals](#362-use-concatenation-when-writing-long-string-literals)
-* [**4.** Comments](#4-comments)
-    * [**4.1.** Begin all comments with a single space](#41-begin-all-comments-with-a-single-space)
-    * [**4.2.** Prefer multiple single-line comments to multi-line block comments](#42-prefer-multiple-single-line-comments-to-multi-line-block-comments)
-    * [**4.3.** Prefer comments on their own line to trailing comments](#43-prefer-comments-on-their-own-line-to-trailing-comments)
-    * [**4.4.** Trailing comments should have one space between "//" and the end of the line](#44-trailing-comments-should-have-one-space-between--and-the-end-of-the-line)
-    * [**4.5.** Documenting comments](#45-documenting-comments)
-        * [**4.5.1.** Document all classes and interfaces](#451-document-all-classes-and-interfaces)
-        * [**4.5.2.** Document all functions and methods](#452-document-all-functions-and-methods)
-        * [**4.5.3.** Document the impure behavior of functions](#453-document-the-impure-behavior-of-functions)
-        * [**4.5.4.** Document all constants and enumerations](#454-document-all-constants-and-enumerations)
-        * [**4.5.6.** Document variables or attributes that are not completely self-explanatory](#456-document-variables-or-attributes-that-are-not-completely-self-explanatory)
-        * [**4.5.6.** Document statements or expressions that are not completely self-explanatory](#456-document-statements-or-expressions-that-are-not-completely-self-explanatory)
-    * [**4.6.** Todos](#46-todos)
-        * [**4.6.1.** Todo comments should begin with "// TODO:"](#461-todo-comments-should-begin-with--todo)
-        * [**4.6.2.** Todo comments should include an explanation of the unfinished task](#462-todo-comments-should-include-an-explanation-of-the-unfinished-task)
-        * [**4.6.3.** Todo comments should include the URL for a relevant issue or PR](#463-todo-comments-should-include-the-url-for-a-relevant-issue-or-pr)
-* [**5.** Names](#5-names)
-    * [**5.1.** Use descriptive names](#51-use-descriptive-names)
-    * [**5.2.** Do not use needless or unconventional abbreviations](#52-do-not-use-needless-or-unconventional-abbreviations)
-    * [**5.3.** Names should contain only "A"-"Z", "a"-"z", and "0"-"9"](#53-names-should-contain-only-a-z-a-z-and-0-9)
-    * [**5.4.** Classes and constants should have PascalCase names](#54-classes-and-constants-should-have-pascalcase-names)
-    * [**5.5.** Functions and variables should have camelCase names](#55-functions-and-variables-should-have-camelcase-names)
-    * [**5.6.** TypeScript source files should have camelCase names](#56-typescript-source-files-should-have-camelcase-names)
-    * [**5.7.** Single-character names](#57-single-character-names)
-        * [**5.7.1.** Single-character names should not be used except as mentioned in **5.7.**](#571-single-character-names-should-not-be-used-except-as-mentioned-in-57)
-        * [**5.7.2.** Parameters with very clear purpose may be named "a", "b", "c", and so on](#572-parameters-with-very-clear-purpose-may-be-named-a-b-c-and-so-on)
-        * [**5.7.3.** The interpolant parameter should be named "t"](#573-the-interpolant-parameter-should-be-named-t)
-        * [**5.7.4.** Extremely generic type parameters may be named "T"](#574-extremely-generic-type-parameters-may-be-named-t)
-        * [**5.7.5.** Coordinates should be named "x", "y", "z", and "w"](#575-coordinates-should-be-named-x-y-z-and-w)
-        * [**5.7.6.** Vector components should be named "ijk" or "xyzw"](#576-vector-components-should-be-named-ijk-or-xyzw)
-* [**6.** Syntax conventions](#6-syntax-conventions)
-    * [**6.1.** Do not use "eval" or the function constructor](#61-do-not-use-eval-or-the-function-constructor)
-    * [**6.2.** Do not use "var"](#62-do-not-use-var)
-    * [**6.3.** Prefer "const" to "let" when declaring variables](#63-prefer-const-to-let-when-declaring-variables)
-    * [**6.4.** Do not use undeclared variables](#64-do-not-use-undeclared-variables)
-    * [**6.5.** Use seperate declarations](#65-use-seperate-declarations)
-    * [**6.6.** Prefer "if" and "else if" over "switch" and "case"](#66-prefer-if-and-else-if-over-switch-and-case)
-    * [**6.7.** Do not nest ternary expressions](#67-do-not-nest-ternary-expressions)
-    * [**6.8.** Prefer strict equality over regular equality](#68-prefer-strict-equality-over-regular-equality)
-    * [**6.9.** Prefer "as" when writing type assertions](#69-prefer-as-when-writing-type-assertions)
-    * [**6.10.** Prefer Type[] to Array](#610-prefer-type-to-array)
-    * [**6.11.** Do not refer to the "arguments" object](#611-do-not-refer-to-the-arguments-object)
-    * [**6.12.** Prefer rest parameters over referring to the "arguments" object](#612-prefer-rest-parameters-over-referring-to-the-arguments-object)
-    * [**6.13.** Avoid the spread operator in array and object literals](#613-avoid-the-spread-operator-in-array-and-object-literals)
-    * [**6.14.** Do not mix full object properties with shorthand properties](#614-do-not-mix-full-object-properties-with-shorthand-properties)
-    * [**6.15.** Imports](#615-imports)
-        * [**6.15.1.** Imports belong at the beginning of a source file](#6151-imports-belong-at-the-beginning-of-a-source-file)
-        * [**6.15.2.** Prefer selective imports over default imports](#6152-prefer-selective-imports-over-default-imports)
-        * [**6.15.3.** Prefer absolute over relative imports](#6153-prefer-absolute-over-relative-imports)
-        * [**6.15.4.** Group and order imports logically, then alphabetically by filename](#6154-group-and-order-imports-logically-then-alphabetically-by-filename)
-        * [**6.15.5.** Do not include unused imports](#6155-do-not-include-unused-imports)
-        * [**6.15.6.** Avoid importing modules for side-effects only](#6156-avoid-importing-modules-for-side-effects-only)
-    * [**6.16.** Ordering of class members](#616-ordering-of-class-members)
-        * [**6.16.1.** Declare static attributes first](#6161-declare-static-attributes-first)
-        * [**6.16.2.** Declare instance attributes second](#6162-declare-instance-attributes-second)
-        * [**6.16.3.** Declare the constructor third](#6163-declare-the-constructor-third)
-        * [**6.16.4.** Declare static member functions fourth](#6164-declare-static-member-functions-fourth)
-        * [**6.16.5.** Declare instance methods last](#6165-declare-instance-methods-last)
-* [**7.** Program logic conventions](#7-program-logic-conventions)
-    * [**7.1.** Prefer local state over global state](#71-prefer-local-state-over-global-state)
-    * [**7.2.** Prefer immutable state over mutable state](#72-prefer-immutable-state-over-mutable-state)
-    * [**7.3.** Prefer pure functions over impure functions](#73-prefer-pure-functions-over-impure-functions)
-    * [**7.4.** Functions should not modify their inputs](#74-functions-should-not-modify-their-inputs)
-    * [**7.5.** Class getters should treat the instance as logically const](#75-class-getters-should-treat-the-instance-as-logically-const)
-    * [**7.6.** Prefer template strings over concatenation](#76-prefer-template-strings-over-concatenation)
-    * [**7.7.** Prefer joining over repeated concatenation](#77-prefer-joining-over-repeated-concatenation)   
+* [**1.** Whitespace](#user-content-1.)
+    * [**1.1.** Indent using four spaces](#user-content-1.1.)
+    * [**1.2.** Do not use double indents](#user-content-1.2.)
+    * [**1.3.** Do not use partial indents](#user-content-1.3.)
+    * [**1.4.** Whitespace as it pertains to braces, brackets, and paretheses](#user-content-1.4.)
+        * [**1.4.1.** No characters inside empty literals, blocks, or expressions](#user-content-1.4.1.)
+        * [**1.4.2.** Nested code should be indented at one additional level](#user-content-1.4.2.)
+        * [**1.4.3.** Code within braces should not be in-line](#user-content-1.4.3.)
+        * [**1.4.4.** Do not put open braces on their own line](#user-content-1.4.4.)
+        * [**1.4.5.** Do not pad code between paretheses or brackets](#user-content-1.4.5.)
+    * [**1.5.** Use a single space after colons but no whitespace before](#user-content-1.5.)
+    * [**1.5.** Use whitespace after commas but not before](#user-content-1.5.)
+    * [**1.6.** Infix operators](#user-content-1.6.)
+        * [**1.6.1.** Put a single space between an infix operator and its left operand](#user-content-1.6.1.)
+        * [**1.6.2.** Put whitespace between an infix operator and its right operand](#user-content-1.6.2.)
+* [**2.** Newlines](#user-content-2.)
+    * [**2.1.** Lines should not exceed eighty characters](#user-content-2.1.)
+    * [**2.4.** Line breaks](#user-content-2.4.)
+        * [**2.4.1.** Line breaks should not occur anywhere not mentioned in **2.4.**](#user-content-2.4.1.)
+        * [**2.4.2.** Line breaks should always occur after a semicolon](#user-content-2.4.2.)
+        * [**2.4.3.** Line breaks may occur after a comma](#user-content-2.4.3.)
+        * [**2.4.4.** Line breaks may occur after an open brace, bracket, or parethese](#user-content-2.4.4.)
+        * [**2.4.5.** Line breaks may occur after an infix operator](#user-content-2.4.5.)
+        * [**2.4.6.** Line breaks may occur after the last expression in a list](#user-content-2.4.6.)
+        * [**2.4.7.** Line breaks may occur after either symbol of a ternary expression](#user-content-2.4.7.)
+    * [**2.2.** Blank lines](#user-content-2.2.)
+        * [**2.2.1.** Source files should not begin with a blank line](#user-content-2.2.1.)
+        * [**2.2.2.** Functions and methods should be padded by blank lines](#user-content-2.2.2.)
+        * [**2.2.3.** Function blocks should not contain blank lines](#user-content-2.2.3.)
+        * [**2.2.4.** Logical groups of imports should be padded by blank lines](#user-content-2.2.4.)
+        * [**2.2.5.** Logical groups of class members should be padded by blank lines](#user-content-2.2.5.)
+    * [**2.5.** There should be a newline at the end of each source file](#user-content-2.5.)
+* [**3.** Punctuation](#user-content-3.)
+    * [**3.1.** Always use semicolons at the end of statements](#user-content-3.1.)
+    * [**3.2.** Use trailing commas in multi-line lists](#user-content-3.2.)
+    * [**3.3.** Always enclose block statements within braces](#user-content-3.3.)
+    * [**3.4.** Use parentheses generously when mixing infix operators](#user-content-3.4.)
+    * [**3.5.** Arrow functions](#user-content-3.5.)
+        * [**3.5.1.** Prefer parentheses around arrow function parameters](#user-content-3.5.1.)
+        * [**3.5.2.** Prefer braces around arrow function bodies](#user-content-3.5.2.)
+    * [**3.6.** Strings](#user-content-3.6.)
+        * [**3.6.1.** Prefer double-quoted strings](#user-content-3.6.1.)
+        * [**3.6.2.** Use concatenation when writing long string literals](#user-content-3.6.2.)
+* [**4.** Comments](#user-content-4.)
+    * [**4.1.** Begin all comments with a single space](#user-content-4.1.)
+    * [**4.2.** Prefer multiple single-line comments to multi-line block comments](#user-content-4.2.)
+    * [**4.3.** Prefer comments on their own line to trailing comments](#user-content-4.3.)
+    * [**4.4.** Trailing comments should have one space between "//" and the end of the line](#user-content-4.4.)
+    * [**4.5.** Documenting comments](#user-content-4.5.)
+        * [**4.5.1.** Document all classes and interfaces](#user-content-4.5.1.)
+        * [**4.5.2.** Document all functions and methods](#user-content-4.5.2.)
+        * [**4.5.3.** Document the impure behavior of functions](#user-content-4.5.3.)
+        * [**4.5.4.** Document all constants and enumerations](#user-content-4.5.4.)
+        * [**4.5.6.** Document variables or attributes that are not completely self-explanatory](#user-content-4.5.6.)
+        * [**4.5.6.** Document statements or expressions that are not completely self-explanatory](#user-content-4.5.6.)
+    * [**4.6.** Todos](#user-content-4.6.)
+        * [**4.6.1.** Todo comments should begin with "// TODO:"](#user-content-4.6.1.)
+        * [**4.6.2.** Todo comments should include an explanation of the unfinished task](#user-content-4.6.2.)
+        * [**4.6.3.** Todo comments should include the URL for a relevant issue or PR](#user-content-4.6.3.)
+* [**5.** Names](#user-content-5.)
+    * [**5.1.** Use descriptive names](#user-content-5.1.)
+    * [**5.2.** Do not use needless or unconventional abbreviations](#user-content-5.2.)
+    * [**5.3.** Names should contain only "A"-"Z", "a"-"z", and "0"-"9"](#user-content-5.3.)
+    * [**5.4.** Classes and constants should have PascalCase names](#user-content-5.4.)
+    * [**5.5.** Functions and variables should have camelCase names](#user-content-5.5.)
+    * [**5.6.** TypeScript source files should have camelCase names](#user-content-5.6.)
+    * [**5.7.** Single-character names](#user-content-5.7.)
+        * [**5.7.1.** Single-character names should not be used except as mentioned in **5.7.**](#user-content-5.7.1.)
+        * [**5.7.2.** Parameters with very clear purpose may be named "a", "b", "c", and so on](#user-content-5.7.2.)
+        * [**5.7.3.** The interpolant parameter should be named "t"](#user-content-5.7.3.)
+        * [**5.7.4.** Extremely generic type parameters may be named "T"](#user-content-5.7.4.)
+        * [**5.7.5.** Coordinates should be named "x", "y", "z", and "w"](#user-content-5.7.5.)
+        * [**5.7.6.** Vector components should be named "ijk" or "xyzw"](#user-content-5.7.6.)
+* [**6.** Syntax conventions](#user-content-6.)
+    * [**6.1.** Do not use "eval" or the function constructor](#user-content-6.1.)
+    * [**6.2.** Do not use "var"](#user-content-6.2.)
+    * [**6.3.** Prefer "const" to "let" when declaring variables](#user-content-6.3.)
+    * [**6.4.** Do not use undeclared variables](#user-content-6.4.)
+    * [**6.5.** Use seperate declarations](#user-content-6.5.)
+    * [**6.6.** Prefer "if" and "else if" over "switch" and "case"](#user-content-6.6.)
+    * [**6.7.** Do not nest ternary expressions](#user-content-6.7.)
+    * [**6.8.** Prefer strict equality over regular equality](#user-content-6.8.)
+    * [**6.9.** Prefer "as" when writing type assertions](#user-content-6.9.)
+    * [**6.10.** Prefer Type[] to Array](#user-content-6.10.)
+    * [**6.11.** Do not refer to the "arguments" object](#user-content-6.11.)
+    * [**6.12.** Prefer rest parameters over referring to the "arguments" object](#user-content-6.12.)
+    * [**6.13.** Avoid the spread operator in array and object literals](#user-content-6.13.)
+    * [**6.14.** Do not mix full object properties with shorthand properties](#user-content-6.14.)
+    * [**6.15.** Imports](#user-content-6.15.)
+        * [**6.15.1.** Imports belong at the beginning of a source file](#user-content-6.15.1.)
+        * [**6.15.2.** Prefer selective imports over default imports](#user-content-6.15.2.)
+        * [**6.15.3.** Prefer absolute over relative imports](#user-content-6.15.3.)
+        * [**6.15.4.** Group and order imports logically, then alphabetically by filename](#user-content-6.15.4.)
+        * [**6.15.5.** Do not include unused imports](#user-content-6.15.5.)
+        * [**6.15.6.** Avoid importing modules for side-effects only](#user-content-6.15.6.)
+    * [**6.16.** Ordering of class members](#user-content-6.16.)
+        * [**6.16.1.** Declare static attributes first](#user-content-6.16.1.)
+        * [**6.16.2.** Declare instance attributes second](#user-content-6.16.2.)
+        * [**6.16.3.** Declare the constructor third](#user-content-6.16.3.)
+        * [**6.16.4.** Declare static member functions fourth](#user-content-6.16.4.)
+        * [**6.16.5.** Declare instance methods last](#user-content-6.16.5.)
+* [**7.** Program logic conventions](#user-content-7.)
+    * [**7.1.** Prefer local state over global state](#user-content-7.1.)
+    * [**7.2.** Prefer immutable state over mutable state](#user-content-7.2.)
+    * [**7.3.** Prefer pure functions over impure functions](#user-content-7.3.)
+    * [**7.4.** Functions should not modify their inputs](#user-content-7.4.)
+    * [**7.5.** Class getters should treat the instance as logically const](#user-content-7.5.)
+    * [**7.6.** Prefer template strings over concatenation](#user-content-7.6.)
+    * [**7.7.** Prefer joining over repeated concatenation](#user-content-7.7.)   
 
 
 
-## 1. Whitespace
+## <a id="1."></a> 1. Whitespace
 
 The following guidelines mainly pertain to the use of whitespace in code.
 
-### 1.1. Indent using four spaces
+### <a id="1.1."></a> 1.1. Indent using four spaces
 
 Code is indented using four space characters.
 Do not indent with tab characters.
@@ -154,7 +163,7 @@ function myFunction(): void {
 }
 ```
 
-### 1.2. Do not use double indents
+### <a id="1.2."></a> 1.2. Do not use double indents
 
 Indentation must be in such a way that each line is indented at either the
 same level as the last line, one more level, or one less.
@@ -175,19 +184,19 @@ myArray.map((value) => {
 });
 ```
 
-### 1.3. Do not use partial indents
+### <a id="1.3."></a> 1.3. Do not use partial indents
 
 There should never be a partial change in indentation.
 All changes in indentation from one line to the next should always be
 in multiples of four space characters.
 
-### 1.4. Whitespace as it pertains to braces, brackets, and paretheses
+### <a id="1.4."></a> 1.4. Whitespace as it pertains to braces, brackets, and paretheses
 
 The following guidelines mainly pertain to how whitespace should be
 used around braces `{}`, square brackets `[]`, angle brackets `<>`, and
 parentheses `()`.
 
-#### 1.4.1. No characters inside empty literals, blocks, or expressions
+#### <a id="1.4.1."></a> 1.4.1. No characters inside empty literals, blocks, or expressions
 
 Where an open brace `{`, parenthese `(`, etc. is followed by a corresponding
 closing brace `}`, parenthese `)`, etc. with no code in between, there should
@@ -211,7 +220,7 @@ myFunctionInvokedWithNoArguments();
 while(myIndex++ < myMaximumIndex){}
 ```
 
-#### 1.4.2. Nested code should be indented at one additional level
+#### <a id="1.4.2."></a> 1.4.2. Nested code should be indented at one additional level
 
 Where a statement is spread across multiple lines, the lines between a
 corresponding pair of braces `{}`, paretheses `()`, square brackets `[]`,
@@ -238,7 +247,7 @@ const myMultiLineArrayLiteral: string[] = [
 ];
 ```
 
-#### 1.4.3. Code within braces should not be in-line
+#### <a id="1.4.3."></a> 1.4.3. Code within braces should not be in-line
 
 Open braces `{` should always be followed by a newline and close braces `}`
 should always be preceded by a newline.
@@ -255,13 +264,13 @@ const myObject: Object = {
 };
 ```
 
-#### 1.4.4. Do not put open braces on their own line
+#### <a id="1.4.4."></a> 1.4.4. Do not put open braces on their own line
 
 Open braces `{` generally should _not_ be preceded by a newline.
 Open braces `{` should generally be on the same line as the statement or
 expression that they are a part of.
 
-#### 1.4.5. Do not pad code between paretheses or brackets
+#### <a id="1.4.5."></a> 1.4.5. Do not pad code between paretheses or brackets
 
 Except for where an expression is distributed across several lines due to its
 length, expressions or blocks inside paretheses `()`, square brackets `[]`,
@@ -282,7 +291,7 @@ const myArrayTooLongToFitOnOneLine = [
 ];
 ```
 
-### 1.5. Use a single space after colons but no whitespace before
+### <a id="1.5."></a> 1.5. Use a single space after colons but no whitespace before
 
 In objects and in typed declarations, there should be a single space after each
 colon `:` and no space before it.
@@ -293,7 +302,7 @@ const myObject: Object {
 };
 ```
 
-### 1.5. Use whitespace after commas but not before
+### <a id="1.5."></a> 1.5. Use whitespace after commas but not before
 
 In comma-separated lists, there should be whitespace after each comma `,`
 and no space before it.
@@ -316,18 +325,18 @@ const myMultiLineArray: string[] = [
 ];
 ```
 
-### 1.6. Infix operators
+### <a id="1.6."></a> 1.6. Infix operators
 
 The following guidelines mainly pertain to the use of whitespace around
 infix operators, e.g. `+` or `*`.
 
-### 1.6.1. Put a single space between an infix operator and its left operand
+### <a id="1.6.1."></a> 1.6.1. Put a single space between an infix operator and its left operand
 
 Infix operators should appear on the same line as the last character of their
 left operand. They should be separated from the last non-whitespace character
 of that left operand by a single space character.
 
-### 1.6.2. Put whitespace between an infix operator and its right operand
+### <a id="1.6.2."></a> 1.6.2. Put whitespace between an infix operator and its right operand
 
 An infix operator should have either a single space separating it from the
 first non-whitespace character of its right operand, or it should be
@@ -348,23 +357,23 @@ const myMultiLineExpression: boolean = (
 
 
 
-## 2. Newlines
+## <a id="2."></a> 2. Newlines
 
 The following guidelines mainly pertain to the placement of new lines and
 blank lines in code.
 
-### 2.1. Lines should not exceed eighty characters
+### <a id="2.1."></a> 2.1. Lines should not exceed eighty characters
 
 In general, no one line of code should exceed 80 characters.
 Please consider eighty characters to be a soft limit and one hundred characters
 to be a hard length limit.
 
-### 2.4. Line breaks
+### <a id="2.4."></a> 2.4. Line breaks
 
 The following guidelines mainly pertain to where line breaks should appear
 in code.
 
-#### 2.4.6. Line breaks should not occur anywhere not mentioned in 2.4.
+#### <a id="2.4.6."></a> 2.4.6. Line breaks should not occur anywhere not mentioned in 2.4.
 
 In general, line breaks on lines containing code should not occur under
 circumstances other than the ones explicitly mentioned below.
@@ -375,7 +384,7 @@ However, this style of comments is not encouraged.
 In general, comments should appear on their own lines and not at the end
 of a line of code. (See `4.3.`.)
 
-#### 2.4.2. Line breaks should always occur after a semicolon
+#### <a id="2.4.2."></a> 2.4.2. Line breaks should always occur after a semicolon
 
 Semicolons terminating a statement should be immediately followed by a
 newline. Two statements should not appear on the same line.
@@ -385,7 +394,7 @@ const myFirstDeclaration: number = 1;
 const mySecondDeclaration: number = 2;
 ```
 
-#### 2.4.3. Line breaks may occur after a comma
+#### <a id="2.4.3."></a> 2.4.3. Line breaks may occur after a comma
 
 Long lists of arguments, parameters, attributes, or other comma-separated
 lists may be broken up by placing newlines after the commas.
@@ -401,12 +410,12 @@ const myMultiLineArray: number[] = [
 ];
 ```
 
-#### 2.4.4. Line breaks may occur after an open brace, bracket, or parethese
+#### <a id="2.4.4."></a> 2.4.4. Line breaks may occur after an open brace, bracket, or parethese
 
 The code in between braces, brackets, etc. may appear on separate lines
 and be indented at one additional level.
 
-#### 2.4.5. Line breaks may occur after an infix operator
+#### <a id="2.4.5."></a> 2.4.5. Line breaks may occur after an infix operator
 
 It is appropriate for a line break to appear after an infix operator and
 before its right operand.
@@ -418,7 +427,7 @@ const myMultiLineExpression: boolean = (
 );
 ```
 
-#### 2.4.6. Line breaks may occur after the last expression in a list
+#### <a id="2.4.6."></a> 2.4.6. Line breaks may occur after the last expression in a list
 
 The last character of a multi-line list should normally be a trailing comma.
 However, in the case that the list appears on one line yet not on the same
@@ -431,7 +440,7 @@ const myValue: number = myMultiLineFunctionInvocation(
 );
 ```
 
-#### 2.4.7. Line breaks may occur after either symbol of a ternary expression
+#### <a id="2.4.7."></a> 2.4.7. Line breaks may occur after either symbol of a ternary expression
 
 A line break may immediately follow the first `?` or second `:` symbol of
 a ternary expression, or both, when breaking the expression across several
@@ -444,17 +453,17 @@ const myTernaryExpressionResult: string = (myCondition ?
 );
 ```
 
-### 2.2. Blank lines
+### <a id="2.2."></a> 2.2. Blank lines
 
 The following guidelines mainly specifically to the placement of blank lines.
 A blank line is a line which contains no characters or which contains
 only whitespace characters.
 
-#### 2.2.1. Source files should not begin with a blank line
+#### <a id="2.2.1."></a> 2.2.1. Source files should not begin with a blank line
 
 The first line in a source file should not be a blank line.
 
-#### 2.2.2. Functions and methods should be padded by blank lines
+#### <a id="2.2.2."></a> 2.2.2. Functions and methods should be padded by blank lines
 
 In general, function or method declarations should be padded on each side
 by a single blank line, except for where the immediately previous or following
@@ -501,7 +510,7 @@ class MyClass {
 }
 ```
 
-#### 2.2.3. Function blocks should not contain blank lines
+#### <a id="2.2.3."></a> 2.2.3. Function blocks should not contain blank lines
 
 In general, the implementation of a function or method should not contain
 blank lines.
@@ -511,35 +520,35 @@ by blank lines.
 If a function is too long or complex to be readable without those empty lines,
 then parts of the implementation should be moved into other helper functions.
 
-#### 2.2.4. Logical groups of imports should be padded by blank lines
+#### <a id="2.2.4."></a> 2.2.4. Logical groups of imports should be padded by blank lines
 
 Logical groups of imports should be separated from each other by a single
 blank line.
 See `6.15.` for more information about how imports should be grouped.
 
-#### 2.2.5. Logical groups of class members should be padded by blank lines
+#### <a id="2.2.5."></a> 2.2.5. Logical groups of class members should be padded by blank lines
 
 Logical groups of class members should be separated from each other by a single
 blank line.
 See `6.16.` for more information about how class members should be grouped.
 
-### 2.5. There should be a newline at the end of each source file
+### <a id="2.5."></a> 2.5. There should be a newline at the end of each source file
 
 TypeScript source files should terminate with a newline character `\n`.
 
 
 
-## 3. Punctuation
+## <a id="3."></a> 3. Punctuation
 
 The following guidelines mainly pertain to the use of punctuation characters
 in code.
 
-### 3.1. Always use semicolons at the end of statements
+### <a id="3.1."></a> 3.1. Always use semicolons at the end of statements
 
 Statements should always be terminated by a semicolon `;`.
 Do not trust JavaScript's automatic semicolon insertion to get it right.
 
-### 3.2. Use trailing commas in multi-line lists
+### <a id="3.2."></a> 3.2. Use trailing commas in multi-line lists
 
 Where it is syntactically valid, the last item in a comma-separated list that
 spans more than one line should be followed by a comma `,`.
@@ -552,7 +561,7 @@ const myMultiLineArray: number[] = [
 ];
 ```
 
-### 3.3. Always enclose block statements within braces
+### <a id="3.3."></a> 3.3. Always enclose block statements within braces
 
 Block statements such as the body of a loop or an `if` statement should
 always be enclosed within braces, even if it is syntactically valid to
@@ -572,7 +581,7 @@ while(myLoopCondition){
 }
 ```
 
-### 3.4. Use parentheses generously when mixing infix operators
+### <a id="3.4."></a> 3.4. Use parentheses generously when mixing infix operators
 
 When a single expression contains several different infix operators, each group
 of identical operators should generally be enclosed within parentheses `()`.
@@ -590,12 +599,12 @@ const myBoolean: boolean = (
 );
 ```
 
-### 3.5. Arrow functions
+### <a id="3.5."></a> 3.5. Arrow functions
 
 The following guidelines mainly pertain to the use of punctuation characters
 as they apply to arrow functions.
 
-#### 3.5.1. Prefer parentheses around arrow function parameters
+#### <a id="3.5.1."></a> 3.5.1. Prefer parentheses around arrow function parameters
 
 In general, the parameter list of an arrow function should always be enclosed
 within paretheses `()`, even when there is only a single parameter.
@@ -606,7 +615,7 @@ myArray.map((value) => {
 });
 ```
 
-#### 3.5.2. Prefer braces around arrow function bodies
+#### <a id="3.5.2."></a> 3.5.2. Prefer braces around arrow function bodies
 
 In general, the bodies of arrow functions should always be enclosed within
 braces `{}`, even when the function body contains only a `return` statement.
@@ -617,12 +626,12 @@ myArray.filter((value) => {
 });
 ```
 
-### 3.6. Strings
+### <a id="3.6."></a> 3.6. Strings
 
 The following guidelines mainly pertain to the use of punctuation characters
 as they apply to string literals.
 
-#### 3.6.1. Prefer double-quoted strings
+#### <a id="3.6.1."></a> 3.6.1. Prefer double-quoted strings
 
 String literals should be double-quoted `""`.
 In general, they should not ever be single-quoted `''`, even when the literal
@@ -635,7 +644,7 @@ string literals that do not actually contain any interpolation.
 const myString: string = "You say \"goodbye\" and I say \"hello\".";
 ```
 
-#### 3.6.2. Use concatenation when writing long string literals
+#### <a id="3.6.2."></a> 3.6.2. Use concatenation when writing long string literals
 
 String literals that are too long to fit on a single line should be spread
 across multiple lines by concatenating many shorter string literals.
@@ -651,11 +660,11 @@ const myLongStringLiteral = (
 
 
 
-## 4. Comments
+## <a id="4."></a> 4. Comments
 
 The following guidelines mainly pertain to what is expected of code comments.
 
-### 4.1. Begin all comments with a single space
+### <a id="4.1."></a> 4.1. Begin all comments with a single space
 
 There should be a single space character in between a comment's opening
 slashes `//` and the first character of the comment's text.
@@ -664,7 +673,7 @@ slashes `//` and the first character of the comment's text.
 // Note the space at the beginning of this comment!
 ```
 
-### 4.2. Prefer multiple single-line comments to multi-line block comments
+### <a id="4.2."></a> 4.2. Prefer multiple single-line comments to multi-line block comments
 
 Long comments should be spread across multiple single line comments
 (i.e. `// comment`) rather than given in a single multi-line block comment
@@ -679,7 +688,7 @@ function myFunction(value: number): number {
 }
 ```
 
-### 4.3. Prefer comments on their own line to trailing comments
+### <a id="4.3."></a> 4.3. Prefer comments on their own line to trailing comments
 
 Comments should usually not be on the same line as code.
 Comments should be on their own line, preceding the code that they apply to.
@@ -689,7 +698,7 @@ Comments should be on their own line, preceding the code that they apply to.
 let myVariable: number = 0;
 ```
 
-### 4.4. Trailing comments should have one space between "//" and the end of the line
+### <a id="4.4."></a> 4.4. Trailing comments should have one space between "//" and the end of the line
 
 Note that `4.3.` discourages the use of trailing comments.
 When trailing comments _are_ used, there should always be exactly one space
@@ -700,12 +709,12 @@ trailing comment.
 doStuff(); // My trailing comment
 ```
 
-### 4.5. Documenting comments
+### <a id="4.5."></a> 4.5. Documenting comments
 
 The following guidelines mainly pertain to when documenting comments are
 encouraged or required.
 
-#### 4.5.1. Document all classes and interfaces
+#### <a id="4.5.1."></a> 4.5.1. Document all classes and interfaces
 
 Every class and interface should have a comment explaining its purpose, even
 if it is only repeating information that should be self-evident.
@@ -724,7 +733,7 @@ class MyColorClass {
 }
 ```
 
-#### 4.5.2. Document all functions and methods
+#### <a id="4.5.2."></a> 4.5.2. Document all functions and methods
 
 Every function or method should have a comment explaining its purpose, even
 if it is only repeating information that should be self-evident.
@@ -736,7 +745,7 @@ function sayHello(): void {
 }
 ```
 
-#### 4.5.3. Document the impure behavior of functions
+#### <a id="4.5.3."></a> 4.5.3. Document the impure behavior of functions
 
 Functions and methods with impure behavior should have that impure behavior
 documented in comments to the greatest extent that is practical.
@@ -753,7 +762,7 @@ function myFunctionWithSideEffects(): void {
 }
 ```
 
-#### 4.5.4. Document all constants and enumerations
+#### <a id="4.5.4."></a> 4.5.4. Document all constants and enumerations
 
 Constants - defined as values set once and never reassigned, not necessarily
 any variable declared using `const` - should always be accompanied by a comment
@@ -777,13 +786,13 @@ enum LinedefTextureFlags {
 }
 ```
 
-#### 4.5.6. Document variables or attributes that are not completely self-explanatory
+#### <a id="4.5.6."></a> 4.5.6. Document variables or attributes that are not completely self-explanatory
 
 It is not necessary to write a comment explaining every variable or attribute,
 but those whose function is not immediately obvious from looking at the
 declaration should be accompanied by documentation comments.
 
-#### 4.5.6. Document statements or expressions that are not completely self-explanatory
+#### <a id="4.5.6."></a> 4.5.6. Document statements or expressions that are not completely self-explanatory
 
 It is not necessary, and in fact discouraged, to write a comment explaining
 every statement and expression.
@@ -795,11 +804,11 @@ less obvious purpose should be accompanied by documentation comments.
 doStuffWith(Math.sqrt((x * x) + (y * y)));
 ```
 
-### 4.6. Todos
+### <a id="4.6."></a> 4.6. Todos
 
 The following guidelines mainly pertain to how "TODO" comments should be used.
 
-#### 4.6.1. Todo comments should begin with "// TODO:"
+#### <a id="4.6.1."></a> 4.6.1. Todo comments should begin with "// TODO:"
 
 Comments recording future or unfinished tasks should consistently begin
 with the characters `// TODO: `.
@@ -813,14 +822,14 @@ function myScaffoldingFunction(): void {
 }
 ```
 
-#### 4.6.2. Todo comments should include an explanation of the unfinished task
+#### <a id="4.6.2."></a> 4.6.2. Todo comments should include an explanation of the unfinished task
 
 It is not acceptable to write a todo comment without including some written
 explanation of the task that is not finished.
 Do not write a comment that says `// TODO` without being followed by more
 text explaining why the comment is present.
 
-#### 4.6.3. Todo comments should include the URL for a relevant issue or PR
+#### <a id="4.6.3."></a> 4.6.3. Todo comments should include the URL for a relevant issue or PR
 
 Where practical, todo comments should refer to an issue in the issue tracker,
 or to a relevant pull request.
@@ -836,18 +845,18 @@ const myHelpUrl: string = "";
 
 
 
-## 5. Names
+## <a id="5."></a> 5. Names
 
 The following guidelines mainly pertain to the naming of variables,
 classes, etc. and source file names.
 
-### 5.1. Use descriptive names
+### <a id="5.1."></a> 5.1. Use descriptive names
 
 All classes, functions, variables etc. should be assigned descriptive names
 that make their purpose as clear as possible.
 Avoid using vague or generic names that do not communicate purpose.
 
-### 5.2. Do not use needless or unconventional abbreviations
+### <a id="5.2."></a> 5.2. Do not use needless or unconventional abbreviations
 
 Identifiers should generally not contain abbreviations unless those
 abbreviations are essentially universal and/or the text that they are
@@ -859,7 +868,7 @@ However, "Idx" abbreviating "Index" or "Err" abbreviating "Error" is not
 acceptable. Please use common sense in judging whether an abbreviation is
 really necessary, and whether it might make the code more difficult to read.
 
-### 5.3. Names should contain only "A"-"Z", "a"-"z", and "0"-"9"
+### <a id="5.3."></a> 5.3. Names should contain only "A"-"Z", "a"-"z", and "0"-"9"
 
 Identifiers should be made up only of the characters `A` through `Z`,
 `a` through `z`, and `0` through `9`.
@@ -872,7 +881,7 @@ Do not use characters such as emoji or math symbols in variable names.
 const myAsciiVariableName: number = 0;
 ```
 
-### 5.4. Classes and constants should have PascalCase names
+### <a id="5.4."></a> 5.4. Classes and constants should have PascalCase names
 
 Class and interface names names, constructors, enumerations, and the names of
 constants should be written in PascalCase.
@@ -882,13 +891,13 @@ but rather it refers to any variable that is initialized once and never changed
 during program execution.
 Constants are not a matter of syntax in TypeScript, but a matter of intent.
 
-### 5.5. Functions and variables should have camelCase names
+### <a id="5.5."></a> 5.5. Functions and variables should have camelCase names
 
 Names of functions, methods, variables, attributes, function parameters,
 and anything else that is not mentioned by `5.4.` should be written
 using camelCase.
 
-### 5.6. TypeScript source files should have camelCase names
+### <a id="5.6."></a> 5.6. TypeScript source files should have camelCase names
 
 TypeScript source files and directories containing TypeScript source files
 should be assigned pascalCase names.
@@ -899,13 +908,13 @@ should be assigned pascalCase names.
 - fileType.ts
 ```
 
-### 5.7. Single-character names
+### <a id="5.7."></a> 5.7. Single-character names
 
 The following guidelines mainly pertain to the use of single-character names.
 Single-character names are mostly discouraged, but are still the most
 appropriate naming choice for some cases.
 
-#### 5.7.1. Single-character names should not be used except as mentioned in 5.7.
+#### <a id="5.7.1."></a> 5.7.1. Single-character names should not be used except as mentioned in 5.7.
 
 Except as otherwise mentioned below in `5.7.`, single-character names should
 not normally be used.
@@ -914,7 +923,7 @@ Here is a rule of thumb: Single-character identifiers should only be used when
 it follows a long-standing mathematical or programming convention, such that
 choosing any other name may make the purpose of the variable, etc. less clear.
 
-#### 5.7.2. Parameters with very clear purpose may be named "a", "b", "c", and so on
+#### <a id="5.7.2."></a> 5.7.2. Parameters with very clear purpose may be named "a", "b", "c", and so on
 
 Sequential single-letter identifiers such as `a`, `b`, `c`, and so on are
 acceptable where they are used to name the parameters of a function with very
@@ -928,7 +937,7 @@ myArray.sort((a: number, b: number) => {
 });
 ```
 
-#### 5.7.3. The interpolant parameter should be named "t"
+#### <a id="5.7.3."></a> 5.7.3. The interpolant parameter should be named "t"
 
 Where a parameter or other named value is used as the
 [interpolant parameter of an interpolation function](https://en.wikipedia.org/wiki/Linear_interpolation),
@@ -942,18 +951,18 @@ function lerp(a: number, b: number, t: number): Vector {
 }
 ```
 
-#### 5.7.4. Extremely generic type parameters may be named "T"
+#### <a id="5.7.4."></a> 5.7.4. Extremely generic type parameters may be named "T"
 
 A generic function or class accepting a single type parameter may have
 that parameter named `T` if the purpose of the parameter is generic enough
 to not lend itself to a more descriptive name.
 
-#### 5.7.5. Coordinates should be named "x", "y", "z", and "w"
+#### <a id="5.7.5."></a> 5.7.5. Coordinates should be named "x", "y", "z", and "w"
 
 The single-character names `x`, `y`, `z`, and `w` are acceptable and encouraged
 when they refer to spatial coordinates along the corresponding axes.
 
-#### 5.7.6. Vector components should be named "ijk" or "xyzw"
+#### <a id="5.7.6."></a> 5.7.6. Vector components should be named "ijk" or "xyzw"
 
 The components of vectors or quaternions should normally be named
 either `i`, `j`, `k` or `x`, `y`, `z`, `w`.
@@ -969,18 +978,18 @@ class MyVector {
 
 
 
-## 6. Syntax conventions
+## <a id="6."></a> 6. Syntax conventions
 
 The following guidelines mainly pertain to what TypeScript syntax options should
 be favored or avoided.
 
-### 6.1. Do not use "eval" or the function constructor
+### <a id="6.1."></a> 6.1. Do not use "eval" or the function constructor
 
 Do not use the `eval` built-in function.
 Do not use the `Function` constructor to create a new function.
 This functionality is not efficient and it opens the door to security issues.
 
-### 6.2. Do not use "var"
+### <a id="6.2."></a> 6.2. Do not use "var"
 
 Do not use `var` when declaring variables. Use `let` or `const` instead.
 
@@ -988,18 +997,18 @@ Do not use `var` when declaring variables. Use `let` or `const` instead.
 const myVariable: number = 0;
 ```
 
-### 6.3. Prefer "const" to "let" when declaring variables
+### <a id="6.3."></a> 6.3. Prefer "const" to "let" when declaring variables
 
 Use `const` instead of `let` whenever it is syntactically valid, i.e. when the
 declared reference is never changed.
 
-### 6.4. Do not use undeclared variables
+### <a id="6.4."></a> 6.4. Do not use undeclared variables
 
 Do not use variables without declaring them.
 Do not reference variables that have not yet been declared at the time
 that the code will be executed.
 
-### 6.5. Use seperate declarations
+### <a id="6.5."></a> 6.5. Use seperate declarations
 
 Do not declare multiple variables together on the same line.
 Use separate declarations, with each declaration on its own line.
@@ -1009,7 +1018,7 @@ const myFirstNumber: number = 0;
 const mySecondNumber: number = 0;
 ```
 
-### 6.6. Prefer "if" and "else if" over "switch" and "case"
+### <a id="6.6."></a> 6.6. Prefer "if" and "else if" over "switch" and "case"
 
 Prefer using a series of `if` and `else if` statements instead of using a
 `switch` statement.
@@ -1026,11 +1035,11 @@ if(myVariable === 0){
 }
 ```
 
-### 6.7. Do not nest ternary expressions
+### <a id="6.7."></a> 6.7. Do not nest ternary expressions
 
 Ternary expressions `a ? b : c` should not be nested.
 
-### 6.8. Prefer strict equality over regular equality
+### <a id="6.8."></a> 6.8. Prefer strict equality over regular equality
 
 The strict equality `===` and strict inequalty `!==` operators should be
 used instead of the regular equality `==` and inequality `!=` operators.
@@ -1039,7 +1048,7 @@ used instead of the regular equality `==` and inequality `!=` operators.
 const myComparison: boolean = (myFirstValue === mySecondValue);
 ```
 
-### 6.9. Prefer "as" when writing type assertions
+### <a id="6.9."></a> 6.9. Prefer "as" when writing type assertions
 
 When writing a type assertion, prefer syntax like `value as Type` over
 syntax like `<Type> value`. ([Why?](https://stackoverflow.com/a/33503842/4099022))
@@ -1048,7 +1057,7 @@ syntax like `<Type> value`. ([Why?](https://stackoverflow.com/a/33503842/4099022
 const myValue: number = myOtherValue as number;
 ```
 
-### 6.10. Prefer Type[] to Array<Type>
+### <a id="6.10."></a> 6.10. Prefer Type[] to Array<Type>
 
 When describing an array type, prefer syntax like `Type[]` to syntax like
 `Array<Type>`.
@@ -1057,11 +1066,11 @@ When describing an array type, prefer syntax like `Type[]` to syntax like
 const myStringArray: string[] = ["Hello", "World"];
 ```
 
-### 6.11. Do not refer to the "arguments" object
+### <a id="6.11."></a> 6.11. Do not refer to the "arguments" object
 
 Functions should not refer to the `arguments` object.
 
-### 6.12. Prefer rest parameters over referring to the "arguments" object
+### <a id="6.12."></a> 6.12. Prefer rest parameters over referring to the "arguments" object
 
 Functions which accept a variable number of arguments should do so using a
 rest parameter `...` and not by accessing the `arguments` object.
@@ -1073,7 +1082,7 @@ function myVariadicFunction(...strings: string[]): void {
 }
 ```
 
-### 6.13. Avoid the spread operator in array and object literals
+### <a id="6.13."></a> 6.13. Avoid the spread operator in array and object literals
 
 Prefer using functions like `Array.concat` or `Object.assign` over using
 the spread operator to construct arrays or objects.
@@ -1093,7 +1102,7 @@ const myComposedObject = {};
 Object.assign(myComposedObject, myFirstObject, mySecondObject);
 ```
 
-### 6.14. Do not mix full object properties with shorthand properties
+### <a id="6.14."></a> 6.14. Do not mix full object properties with shorthand properties
 
 An object should either use only shorthand properties or only full properties.
 A single object literal should not mix both types of properties.
@@ -1112,16 +1121,16 @@ const myObjectWithShortProperties: Object = {
 };
 ```
 
-### 6.15. Imports
+### <a id="6.15."></a> 6.15. Imports
 
 The following guidelines mainly pertain to how imports should be written.
 
-#### 6.15.1. Imports belong at the beginning of a source file
+#### <a id="6.15.1."></a> 6.15.1. Imports belong at the beginning of a source file
 
 Import statements should be at the very top of a TypeScript source file.
 They should not appear anywhere else.
 
-#### 6.15.2. Prefer selective imports over default imports
+#### <a id="6.15.2."></a> 6.15.2. Prefer selective imports over default imports
 
 Prefer selective imports (imports with braces `{}`) over default imports
 (imports without braces).
@@ -1138,7 +1147,7 @@ sense to choose a default.
 export default WADFile;
 ```
 
-#### 6.15.3. Prefer absolute over relative imports
+#### <a id="6.15.3."></a> 6.15.3. Prefer absolute over relative imports
 
 Absolute import paths (those starting with an "at" sign `@`) should be
 preferred over relative paths (those starting with a dot `.`).
@@ -1150,7 +1159,7 @@ file `webpack.config.js`.
 import {WADFile} from "@src/wad/file";
 ```
 
-#### 6.15.4. Group and order imports logically, then alphabetically by filename
+#### <a id="6.15.4."></a> 6.15.4. Group and order imports logically, then alphabetically by filename
 
 Imports should first be ordered by logical group, and then alphabetically by
 filename.
@@ -1174,21 +1183,21 @@ import {WADFileList} from "@src/wad/fileList";
 import {LumpTypeView} from "@web/lumpTypeView";
 ```
 
-#### 6.15.5. Do not include unused imports
+#### <a id="6.15.5."></a> 6.15.5. Do not include unused imports
 
 Avoid importing unused symbols or modules.
 
-#### 6.15.6. Avoid importing modules for side-effects only
+#### <a id="6.15.6."></a> 6.15.6. Avoid importing modules for side-effects only
 
 Avoid writing side-effect-only import statements, i.e. statements
 such as `import "module";`.
 
-### 6.16. Ordering of class members
+### <a id="6.16."></a> 6.16. Ordering of class members
 
 The following guidelines mainly pertain to how class member declarations
 should be ordered.
 
-#### 6.16.1. Declare static attributes first
+#### <a id="6.16.1."></a> 6.16.1. Declare static attributes first
 
 Static attributes and constants should come before all other declarations
 in a class.
@@ -1200,7 +1209,7 @@ class MyClass {
 }
 ```
 
-#### 6.16.2. Declare instance attributes second
+#### <a id="6.16.2."></a> 6.16.2. Declare instance attributes second
 
 Instance attributes should be declared after static attributes but before the
 constructor and any member functions or methods.
@@ -1214,7 +1223,7 @@ class MyClass {
 }
 ```
 
-#### 6.16.3. Declare the constructor third
+#### <a id="6.16.3."></a> 6.16.3. Declare the constructor third
 
 The class constructor should come after all static and instance attribute
 declarations but before all method and member function declarations.
@@ -1228,7 +1237,7 @@ class MyClass {
 }
 ```
 
-#### 6.16.4. Declare static member functions fourth
+#### <a id="6.16.4."></a> 6.16.4. Declare static member functions fourth
 
 Static member functions should appear after attribute declarations and
 after the class constructor, but before instance method declarations.
@@ -1242,7 +1251,7 @@ class MyClass {
 }
 ```
 
-#### 6.16.5. Declare instance methods last
+#### <a id="6.16.5."></a> 6.16.5. Declare instance methods last
 
 Instance methods should appear after all other declarations in a class.
 
@@ -1257,12 +1266,12 @@ class MyClass {
 
 
 
-## 7. Program logic conventions
+## <a id="7."></a> 7. Program logic conventions
 
 The following guidelines mainly pertain to the use of consistent logic and design
 conventions in order to keep code modular and maintainable.
 
-### 7.1. Prefer local state over global state
+### <a id="7.1."></a> 7.1. Prefer local state over global state
 
 Code which relies on local state is normally easier to understand and maintain
 than code which relies on global state.
@@ -1271,12 +1280,12 @@ deals with the DOM. However, global state should be avoided when possible.
 Whenever possible, state should be stored locally in scoped variables or
 in class instances.
 
-### 7.2. Prefer immutable state over mutable state
+### <a id="7.2."></a> 7.2. Prefer immutable state over mutable state
 
 Where it will not substantially impact performance in a negative way,
 treat variables and objects as though they were immutable.
 
-### 7.3. Prefer pure functions over impure functions
+### <a id="7.3."></a> 7.3. Prefer pure functions over impure functions
 
 [Pure functions](https://www.sitepoint.com/functional-programming-pure-functions/)
 are those which accept inputs and produce their output without making any
@@ -1291,13 +1300,13 @@ function myPureFunction(value: number): number {
 }
 ```
 
-### 7.4. Functions should not modify their inputs
+### <a id="7.4."></a> 7.4. Functions should not modify their inputs
 
 Avoid writing functions that modify their inputs.
 Ensure that where such functions do exist, their modification of the input
 is clearly documented.
 
-### 7.5. Class getters should treat the instance as logically const
+### <a id="7.5."></a> 7.5. Class getters should treat the instance as logically const
 
 In general, getters (i.e. methods preceded by the `get` keyword) should treat
 the instance `this` as [logically const](http://wiki.c2.com/?LogicalConst).
@@ -1327,7 +1336,7 @@ class MyClass {
 }
 ```
 
-### 7.6. Prefer template strings over concatenation
+### <a id="7.6."></a> 7.6. Prefer template strings over concatenation
 
 Prefer using template strings over string concatenation or joining.
 
@@ -1335,7 +1344,7 @@ Prefer using template strings over string concatenation or joining.
 const myString: string = `${helloString} ${worldString}!`;
 ```
 
-### 7.7. Prefer joining over repeated concatenation
+### <a id="7.7."></a> 7.7. Prefer joining over repeated concatenation
 
 Strings that are incrementally assembled, e.g. in a loop, should have their
 substrings pushed to an array and combined at the end of the loop with a

--- a/style.md
+++ b/style.md
@@ -36,9 +36,9 @@ function myFunction(): void {
 Code should be styled in such a way that each line is indented at either the same level as the last line, one more level, or one less. There should never be a jump of two or more indentation levels between lines. There should never be a partial change in indentation, e.g. one line should not be indented three spaces further than the next.
 
 ``` ts
-myArray.map(value => {
+myArray.map((value) => {
     return transformMyValue(value);
-}).filter(value => {
+}).filter((value) => {
     return filterMyValue(value);
 });
 ```
@@ -248,14 +248,24 @@ const myLongStringLiteral = (
 );
 ```
 
+## Prefer spaces around arrow function parameters
+
+In general, the parameter list of an arrow function should always be enclosed within paretheses `()`.
+
+``` ts
+myArray.map((value) => {
+    return value + value;
+});
+```
+
 ## Prefer braces around arrow function bodies
 
 In general, the bodies of arrow functions should always be enclosed within
 braces `{}`.
 
 ``` ts
-myArray.map(value => {
-    return value + value;
+myArray.filter((value) => {
+    return value > 0;
 });
 ```
 
@@ -361,7 +371,7 @@ function lerp(a: number, b: number, t: number): Vector {
 
 ``` ts
 // Note that `a` and `b` are acceptable parameter names for
-// comparator functions, though single-character variable names
+// comparator functions, even though single-character variable names
 // generally are not allowed.
 myArray.sort((a: number, b: number) => {
     return a - b;

--- a/style.md
+++ b/style.md
@@ -1,0 +1,672 @@
+# Jsdoom Style Guide
+
+The purpose of this style guide is to keep jsdoom's source code readable, approachable, consistent, and maintainable. When contributing to jsdoom, please follow these guidelines. Pull requests containing code that does not follow the guidelines may be rejected until the code has been made conformant.
+
+These are not strict rules! Exceptions are allowed where it improves readability. However, exceptions should be just that: Exceptional. Exceptions should be made sparingly, if they are made at all.
+
+Please [create a GitHub issue](https://github.com/pineapplemachine/jsdoom/issues/new) if you would like to request a change or an addition to this style guide.
+
+Throughout this guide, specific examples of conforming code will be provided like so:
+
+``` ts
+// An example of conforming code
+console.log("jsdoom is pretty neat");
+```
+
+
+
+# Formatting
+
+## Indent using four spaces
+
+Code in jsdoom is indented with four spaces. The line followed by an open brace `{` should be indented one level further than the line with the open brace. The line with the corresponding closing brace `}` should be indented one level less.
+
+``` ts
+// [Comment explaining the purpose of my function]
+function myFunction(): void {
+    doStuff();
+    if(condition){
+        doOtherStuff();
+    }
+}
+```
+
+## No double indents or partial indents
+
+Code should be styled in such a way that each line is indented at either the same level as the last line, one more level, or one less. There should never be a jump of two or more indentation levels between lines. There should never be a partial change in indentation, e.g. one line should not be indented three spaces further than the next.
+
+``` ts
+myArray.map(value => {
+    return transformMyValue(value);
+}).filter(value => {
+    return filterMyValue(value);
+});
+```
+
+## Whitespace around braces
+
+Open braces `{` should always be followed by a newline and close braces `}` should always be preceded by a newline. Open braces `{` generally should _not_ be preceded by a newline.
+
+``` ts
+const myObject: Object = {
+    myAttribute: doStuff({
+        myOption: 1,
+    });
+};
+```
+
+Open braces `{` should generally be on the same line as the statement they pertain to.
+
+``` ts
+while(myCondition){
+    if(myOtherCondition){
+        doStuff();
+    }else{
+        doOtherStuff();
+    }
+}
+```
+
+## Do not pad enclosed expressions with spaces
+
+Except for where an expression is distributed across several lines due to its length, expressions or blocks inside paretheses `()`, square brackets `[]`, or angle brackets `<>` should not have spaces in between the opening bracket or parenthese and the first character of the enclosed expression, nor in between the closing bracket or parenthese and the final character of the enclosed expression.
+
+``` ts
+// No space in between `[` and `1`.
+// No space in between `5` and `]`.
+const myArray: number[] = [1, 2, 3, 4, 5];
+```
+
+``` ts
+// Newlines are okay for spreading a long statement across multiple lines.
+const myArrayTooLongToFitOnOneLine = [
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+];
+```
+
+## Put a newline at the end of files
+
+In general, source files should terminate with a newline character `\n`.
+
+## Keep lines at or under eighty characters
+
+In general, no one line of code should exceed 80 characters. Where it is at all possible, lines should absolutely not exceed 100 characters in length.
+
+``` ts
+const myLongExpressionResult: string = (
+    "This code statement is written in such a way that the line length " +
+    "consistently stays under eighty characters long. " +
+    "This line length limit particularly helps to accomodate those who " +
+    "are limited to smaller screens, or who subscribe to the rather " +
+    "common practice of displaying code from different source locations " +
+    "in two or more columns across a larger screen."
+);
+```
+
+## Always use semicolons
+
+Always put a semicolon `;` at the end of each line. There should not be any whitespace in between the last character on the line and its terminating semicolon.
+
+``` ts
+doStuff();
+```
+
+## Commas belong immediately after the left-hand expression
+
+Commas `,` belong on the same line as the left-hand expression, with no space in between the comma and the last character of the expression.
+The first non-whitespace character of any line of code should never be a comma.
+Commas belong at the end of a line, not at the beginning.
+
+``` ts
+const myArray: string[] = ["Hello", "World"];
+```
+
+## Use trailing commas in multi-line lists
+
+Always put a trailing comma `,` at the end of multi-line lists, where they are syntactically valid.
+
+``` ts
+const myArray: number[] = [
+    0x1000,
+    0x2000,
+    0x4000,
+    0x8000,
+];
+```
+
+## Always enclose block statements within braces
+
+All block statements should be enclosed within braces `{}`, i.e. single-line conditionals or loops without braces around their bodies should not generally be used.
+
+``` ts
+if(myExitCondition){
+    return;
+}
+```
+
+``` ts
+while(myLoopCondition){
+    counter++;
+}
+```
+
+## Function blocks should not contain blank lines
+
+In general, the implementation of a function or method should not contain empty lines. If a function is made up of several different conceptual units, then they should be separated by explanatory comments instead of by empty lines. If a function is too long or complex to be readable without those empty lines, then parts of the implementation should be moved into other helper functions.
+
+``` ts
+// This is a helper function used by myVeryComplicatedProcedure.
+// [Comment explaining the first task]
+function doTheFirstTask(): void {
+    // Imagine this function body is 100 lines long!
+    doStuff();
+}
+
+// This is a helper function used by myVeryComplicatedProcedure.
+// [Comment explaining the second task]
+function doTheSecondTask(): void {
+    // Imagine this function body is 100 lines long!
+    doOtherStuff();
+}
+
+// This is a helper function used by myVeryComplicatedProcedure.
+// [Comment explaining the third task]
+function doTheThirdTask(): void {
+    // Imagine this function body is 100 lines long!
+    doYetMoreStuff();
+}
+
+// [Comment explaining the purpose of my very complicated function]
+// Imagine that this function body would be a dense, unreadable 300 lines
+// if it wasn't broken up into several helper function calls this way!
+function myVeryComplicatedProcedure(): void {
+    // [Comment briefly summarizing the first task]
+    doTheFirstTask();
+    // [Comment briefly summarizing the second task]
+    doTheSecondTask();
+    // [Comment briefly summarizing the third task]
+    doTheThirdTask();
+}
+```
+
+## Pad infix operators with spaces
+
+An infix operator should have whitespace separating it from both operands.
+
+``` ts
+const mySum: number = 100 + 200;
+```
+
+``` ts
+const myValue: number = myNumberArray[myIndex + 10];
+```
+
+## Use parentheses generously when mixing infix operators
+
+When a single expression contains several different infix operators, each group of identical operators should generally be enclosed within parentheses `()`. This helps to avoid any confusion or ambiguity regarding the intended order of operations.
+
+``` ts
+const myValue: number = 10 * (20 + myOtherValue);
+```
+
+``` ts
+const myBoolean: boolean = (
+    (firstCondition || secondCondition) &&
+    (thirdCondition || fourthCondition)
+);
+```
+
+## Use space after colons but not before
+
+In objects and in typed declarations, there should be a single space after each colon `:` and no space before it.
+
+``` ts
+const myObject: Object {
+    myAttribute: "hello world",
+};
+```
+
+## Prefer double-quoted strings
+
+String literals should be double-quoted `""`. In general, they should not ever be single-quoted `''`.
+Template strings (enclosed within backticks ``` `` ```) should generally not be used for string literals that do not actually contain any interpolation.
+
+``` ts
+const myString: string = "You say \"goodbye\" and I say \"hello\".";
+```
+
+## Use concatenation when writing long string literals
+
+String literals that are too long to fit on a single line should be spread across multiple lines by concatenating many shorter string literals.
+
+``` ts
+const myLongStringLiteral = (
+    "This is a long string literal. In fact, it is so long, that it could " +
+    "not possibly fit on a single line and still be readable. " +
+    `Remember that the recommended maximum line length is ${MaxLineLength} ` +
+    "characters!"
+);
+```
+
+## Prefer braces around arrow function bodies
+
+In general, the bodies of arrow functions should always be enclosed within
+braces `{}`.
+
+``` ts
+myArray.map(value => {
+    return value + value;
+});
+```
+
+## Use seperate declarations
+
+Do not declare multiple variables together on the same line. Use separate declarations, with each declaration on its own line.
+
+``` ts
+const myFirstNumber: number = 0;
+const mySecondNumber: number = 0;
+```
+
+## Start all comments with a space
+
+In general, there should always be a single space character in between a comment's opening slashes `//` and the first character of the comment's text.
+
+``` ts
+// Note the space at the beginning of this comment!
+```
+
+## Prefer multiple single-line comments to multi-line block comments
+
+In general, long comments should be spread across multiple single line comments (i.e. `// comment`) rather than given in a single multi-line block comment (i.e. `/* comment */`).
+
+``` ts
+// This is a longer comment providing a lot of information about a function.
+// It describes in detail the function's purpose, its accepted input, and its
+// expected output. It's far too much information to fit on just one line.
+function myFunction(value: number): number {
+    return doStuffWith(value);
+}
+```
+
+## Prefer comments on their own line to trailing comments
+
+In general, comments should be on their own line, preceding the code that they apply to, instead of on the same line, immediately after the code that they apply to.
+
+``` ts
+// [Comment explaining the purpose of my variable]
+let myVariable: number = 0;
+```
+
+## Prefer "as" to type assertions
+
+Prefer syntax such as `value as Type` over `<Type> value`.
+([Why?](https://stackoverflow.com/a/33503842/4099022))
+
+``` ts
+const myValue: number = myOtherValue as number;
+```
+
+## Prefer Type[] to Array<Type>
+    
+Prefer type syntax such as `myArray: string[]` to `myArray: Array<string>`.
+    
+``` ts
+const myStringArray: string[] = ["Hello", "World"];
+```
+
+
+
+# Naming
+
+## Characters allowed in identifiers
+
+In general, dentifiers should be made up only of the characters `A` through `Z`, `a` through `z`, and `0` through `9`. Identifiers generally should not have an underscore `_` in their name, even if they identify private members.
+
+Do not use characters such as emoji or math symbols in variable names.
+
+``` ts
+const myAsciiVariableName: number = 0;
+```
+
+## Use descriptive names
+
+Functions, classes, variables, and other named entities should have informative, descriptive names. Names should generally not contain abbreviations.
+
+"HTML" abbreviating "HypertextMarkupLanguage" ot "WAD" abbreviating "WheresAllTheData" is okay but "Idx" abbreviating "Index" or "Err" abbreviating "Error" is not. Please use common sense in judging whether an abbreviation is really necessary, and whether it might make the code more difficult to read.
+
+Single-letter identifiers are strictly disallowed with the exception of `x`, `y`, `z`, `w`, `i`, `j`, and `k` where specifically used to describe position or vector components, or `a` and `b` where used as the parameters of a comparator function with a clear purpose.
+
+``` ts
+// [Comment explaining the purpose of my vector class]
+class MyVector {
+    x: number;
+    y: number;
+    z: number;
+}
+```
+
+``` ts
+// Note that `a` and `b` are acceptable parameter names for
+// comparator functions, though single-character variable names
+// generally are not allowed.
+myArray.sort((a: number, b: number) => {
+    return a - b;
+});
+```
+
+Do not name loop variables `x` or `i`; use descriptive names for them instead. Prefer identifiers like `vectorIndex` over the less descriptive `index`.
+
+``` ts
+for(let vectorIndex: number = 0; vectorIndex < totalVectors; vectorIndex++){
+    const myVector: Vector = vectors[vectorIndex];
+    doStuffWithVector(myVector);
+}
+```
+
+## Use PascalCase for classes and constants
+
+Class names, constructors, and the names of constants should be written in PascalCase.
+Note that constant in this case does not mean everything declared using `const`, but rather it refers to any variable that is initialized once and never changed during program execution. (Constants are not a matter of syntax in TypeScript, but a matter of intent.)
+
+``` ts
+// [Comment explaining the purpose of my constant]
+const PlaypalLumpName = "PLAYPAL";
+```
+
+``` ts
+// [Comment explaining the purpose of my class]
+class MyClass {
+    // [Comment explaining the purpose of my attribute]
+    myAttribute: string;
+}
+```
+
+## Use camelCase for functions and variables
+
+Names of functions, methods, variables, attributes, and function parameters should be written in camelCase.
+
+``` ts
+// [Comment explaining the usage of this function]
+function getPaletteCount(): number {
+    return 100;
+}
+```
+
+``` ts
+// [Comment explaining the purpose of my class]
+class MyClass {
+    // [Comment explaining the purpose of my attribute]
+    myAttribute: string;
+    
+    // [Comment explaining why this class has a number-squaring helper]
+    mySquaringMethod(value: number): number {
+        return value * value;
+    }
+}
+```
+
+## Use camelCase for TypeScript source file names
+
+TypeScript source files should be assigned pascalCase names.
+
+``` text
+- file.ts
+- fileList.ts
+- fileType.ts
+```
+
+
+# Conventions
+
+## Do not use "eval" or the function constructor
+
+Do not ever use the `eval` built-in function. Do not ever use the `Function` constructor to create a new function. These are inefficient and would make jsdoom vulnerable to arbitrary code execution.
+
+## Do not use "var"
+
+Do not declare variables using `var`. Use `let` or `const` instead.
+
+## Prefer "if" and "else if" over "switch" and "case"
+
+In general, a series of `if` and `else if` statements should be used instead of a `switch` statement.
+
+``` ts
+if(myVariable === 0){
+    doStuff();
+}else if(myVariable === 1){
+    doOtherStuff();
+}else if(myVariable === 2){
+    doYetMoreStuff();
+}else{
+    doDefaultStuff();
+}
+```
+
+## Do not nest ternary expressions
+
+In general, ternary expressions `a ? b : c` should not be nested.
+
+## Prefer strict equality over regular equality
+
+The equality operator `==` and inequality operator `!=` should not generally be used. Prefer the strict equality operator `===` and strict inequality operator `!==` instead.
+
+``` ts
+const myComparison: boolean = (myFirstValue === mySecondValue);
+```
+
+## Prefer local state over global state
+
+Code which relies on local state is easier to understand and maintain than code which relies on global state.
+It is not possible to completely avoid global state, particularly in code that deals with the DOM. However, global state should be avoided when possible. State should instead be stored locally in scoped variables or class instances.
+
+``` ts
+const myConstantVariable: number = 0;
+let myMutableVariable: number = 0;
+```
+
+## Prefer immutable state over mutable state
+
+Use `const` instead of `let` for references which are not changed.
+
+Where it will not substantially impact performance in a negative way, treat variables and objects as immutable.
+
+## Prefer pure functions over impure functions
+
+Pure functions are those which accept inputs and return an output without making any changes to the inputs and without producing any side-effects. In essence, a pure function is one which can be called at any time, any number of times, and the same inputs will always produce the same output.
+
+``` ts
+// [Comment explaining the purpose of my pure function]
+function myPureFunction(value: number): number {
+    return value + value;
+}
+```
+
+## Document the impure behavior of functions
+
+In general, functions with side-effects should be avoided. However, this is often not possible, especially in code that is meant to manipulate DOM state.
+Functions which do have side-effects should have those side-effects clearly documented in code comments.
+
+``` ts
+// [Comment explaining the purpose of my function]
+// [Comment explaining the function's side-effects]
+function myDomRelatedFunction(): void {
+    doStuffWithSideEffects();
+}
+```
+
+In general, functions should not modify their inputs. When they must, it is important that this behavior be documented.
+
+``` ts
+// This function will modify the input object.
+// In particular, it assigns a new value to the object's
+// "myAttribute" attribute.
+function myFunction(myObject: Object): void {
+    myObject.myAttribute = "hello world";
+}
+```
+
+## Class getters should treat the instance as logically const
+
+In general, getters (i.e. methods preceded by the `get` keyword) should treat the instance `this` as [logically const](http://wiki.c2.com/?LogicalConst). Logical const means that the object may technically be modified, but any modification should not affect or be visible to code which uses only the object's intended and documented API.
+
+``` ts
+class MyClass {
+    // Used to cache the result of the myExpensiveProperty getter.
+    private lazilyComputedValue: number = NaN;
+    
+    // No modification of the class instance whatsoever.
+    // `this` is literally const.
+    get myProperty(): number {
+        return 0x0100;
+    }
+    
+    // Modification is trivial to the outside observer.
+    // `this` is logically const.
+    get myExpensiveProperty(): number {
+        if(Number.isNaN(this.lazilyComputedValue)){
+            this.lazilyComputedValue = doExpensiveComputation();
+        }
+        return this.lazilyComputedValue;
+    }
+}
+```
+
+## Explicitly document types
+
+Typing can be a pain when working with the DOM, but an effort should still be made to include correct types for variables, parameters, and retun types. In general, such types should always be included for internal code that does not deal with the DOM or other complex APIs not designed with static types in mind.
+
+## Prefer selective imports over default imports
+
+In general, selective imports should be used instead of default imports. (A default import is one without braces `{}`, e.g. `import DefaultSymbol from "location";`.)
+
+``` ts
+import {WADFile} from "@src/wad/file";
+```
+
+However, modules should still export a default symbol where there is an obvious default.
+
+``` ts
+// Actual export declared in "@src/wad/file"
+export default WADFile;
+```
+
+## Prefer absolute over relative imports
+
+In general, absolute import paths (those starting with an "at" sign `@`) should be preferred over relative paths (those starting with a dot `.`). Note that the meaning of these absolute paths are defined by macros in the TypeScript config file `tsconfig.json` and the webpack config file `webpack.config.js`.
+
+``` ts
+import {WADFile} from "@src/wad/file";
+```
+
+## Order imports logically, then alphabetically by filename
+
+In general, imports should first be ordered by logical group, and then alphabetically by filename. Each group should be separated by a single empty line. Groups should generally be ordered from most general to most specialized. Here is a guideline for how to order these groups:
+
+1. Native dependencies, such as Node.js imports.
+2. External dependencies, i.e. those listed in `package.json`.
+3. Jsdoom library dependencies, e.g. `@src/wad/` or `@src/lumps/`.
+4. Jsdoom UI or engine dependencies, e.g. `@web/`.
+
+``` ts
+import * as fs from "fs";
+import * as path from "path";
+
+import * as UPNG from "upng-js";
+
+import {WADFile} from "@src/wad/file";
+import {WADFileList} from "@src/wad/fileList";
+
+import {LumpTypeView} from "@web/lumpTypeView";
+```
+
+## Order of class member declarations
+
+In classes or objects, attributes should generally be defined in the source in the following order. In general, a single empty line should separate each group of listed declarations from the next group, and single empty line should separate each function or method declaration.
+
+1. Static class attributes.
+2. Instance attributes.
+3. Constructor(s)
+4. Static class functions
+5. Instance methods
+
+``` ts
+// [Comment explaining the purpose of my class]
+class MyClass {
+    // [Comment explaining the purpose of my constant]
+    static readonly MyStaticConstant: number = 0x8000;
+    
+    // [Comment explaining the purpose of my attribute]
+    myFirstAttribute: string;
+    // [Comment explaining the purpose of my attribute]
+    mySecondAttribute: string;
+    
+    constructor() {
+        this.myFirstAttribute = "hello";
+        this.mySecondAttribute = "world";
+    }
+    
+    // [Comment explaining the purpose of my function]
+    static myStaticFunction(): MyClass {
+        return new MyClass();
+    }
+    
+    // [Comment explaining the purpose of my method]
+    getTotalLength(): number {
+        return this.myFirstAttribute.length + this.mySecondAttribute.length;
+    }
+}
+```
+
+## Prefer rest arguments over referring to the arguments object
+
+Functions which accept a variable number of arguments should do so using a rest parameter `...` and not by accessing the `arguments` object. In general, functions should never access or manipulate the `arguments` object.
+
+``` ts
+// [Comment explaining the purpose of my function]
+function myVariadicFunction(...strings: string[]): void {
+    doStuffWith(strings);
+}
+```
+
+## Avoid the spread operator
+
+The spread operator `...` should be avoided except for where it replaces an expression such as `myFunction.apply(null, myArgumentList)` with one such as `myFunction(...myArgumentList)`.
+
+``` ts
+// Use `Array.concat` instead of the spread operator
+const myConcatenatedArray = (
+    myFirstArray.concat(mySecondArray)
+);
+```
+
+``` ts
+// Assign each key individually or, if the keys are numerous or not
+// necessarily known ahead of time, use `Object.assign` instead of
+// using the spread operator.
+const myComposedObject = {};
+Object.assign(myComposedObject, myFirstObject, mySecondObject);
+```
+
+## Prefer template strings over concatenation
+
+In general, template strings should be used instead of string concatenation or joining.
+
+``` ts
+const myString: string = `${helloString} ${worldString}!`;
+```
+
+## Prefer joining over repeated concatenation
+
+Strings that are incrementally assembled, e.g. in a loop, should be pushed to an array and combined at the end of the loop with a single `join` statement. Generally, such strings should not be assembled via repeated concatenation.
+
+``` ts
+// Create a comma-separated list representing the vertexes in an array.
+function vertexListToString(vertexes: Vertex[]): string {
+    const parts: string[] = [];
+    for(const vertex of vertexes){
+        parts.push(`(${vertex.x}, ${vertex.y})`);
+    }
+    return parts.join(", ");
+}
+```

--- a/style.md
+++ b/style.md
@@ -1,25 +1,147 @@
 # Jsdoom Style Guide
 
-The purpose of this style guide is to keep jsdoom's source code readable, approachable, consistent, and maintainable. When contributing to jsdoom, please follow these guidelines. Pull requests containing code that does not follow the guidelines may be rejected until the code has been made conformant.
+The purpose of this style guide is to keep jsdoom's source code readable,
+approachable, consistent, and maintainable.
+When contributing to jsdoom, please follow these guidelines.
+Pull requests containing code that does not follow the guidelines may be
+rejected until the code has been made conformant.
 
-These are not strict rules! Exceptions are allowed where it improves readability. However, exceptions should be just that: Exceptional. Exceptions should be made sparingly, if they are made at all.
+These are not strict rules! Exceptions are allowed where it improves
+readability. However, exceptions should be just that: Exceptional.
+Exceptions should be made sparingly, if they are made at all.
 
-Please [create a GitHub issue](https://github.com/pineapplemachine/jsdoom/issues/new) if you would like to request a change or an addition to this style guide.
+Please [create a GitHub issue](https://github.com/pineapplemachine/jsdoom/issues/new)
+if you would like to request a change or an addition to this style guide.
 
-Throughout this guide, specific examples of conforming code will be provided like so:
+Throughout this guide, specific examples of conforming code will be provided
+like so:
 
 ``` ts
 // An example of conforming code
 console.log("jsdoom is pretty neat");
 ```
 
+# Table of Contents
+
+* [**1.** Whitespace](#1-whitespace)
+    * [**1.1.** Indent using four spaces](#11-indent-using-four-spaces)
+    * [**1.2.** Do not use double indents](#12-do-not-use-double-indents)
+    * [**1.3.** Do not use partial indents](#13-do-not-use-partial-indents)
+    * [**1.4.** Whitespace as it pertains to braces, brackets, and paretheses](#14-whitespace-as-it-pertains-to-braces-brackets-and-paretheses)
+        * [**1.4.1.** No characters inside empty literals, blocks, or expressions](#141-no-characters-inside-empty-literals-blocks-or-expressions)
+        * [**1.4.2.** Nested code should be indented at one additional level](#142-nested-code-should-be-indented-at-one-additional-level)
+        * [**1.4.3.** Code within braces should not be in-line](#143-code-within-braces-should-not-be-in-line)
+        * [**1.4.4.** Do not put open braces on their own line](#144-do-not-put-open-braces-on-their-own-line)
+        * [**1.4.5.** Do not pad code between paretheses or brackets](#145-do-not-pad-code-between-paretheses-or-brackets)
+    * [**1.5.** Use a single space after colons but no whitespace before](#15-use-a-single-space-after-colons-but-no-whitespace-before)
+    * [**1.5.** Use whitespace after commas but not before](#15-use-whitespace-after-commas-but-not-before)
+    * [**1.6.** Infix operators](#16-infix-operators)
+        * [**1.6.1.** Put a single space between an infix operator and its left operand](#161-put-a-single-space-between-an-infix-operator-and-its-left-operand)
+        * [**1.6.2.** Put whitespace between an infix operator and its right operand](#162-put-whitespace-between-an-infix-operator-and-its-right-operand)
+* [**2.** Newlines](#2-newlines)
+    * [**2.1.** Lines should not exceed eighty characters](#21-lines-should-not-exceed-eighty-characters)
+    * [**2.4.** Line breaks](#24-line-breaks)
+        * [**2.4.1.** Line breaks should always occur after a semicolon](#241-line-breaks-should-always-occur-after-a-semicolon)
+        * [**2.4.2.** Line breaks may occur after a comma](#242-line-breaks-may-occur-after-a-comma)
+        * [**2.4.3.** Line breaks may occur after an open brace, bracket, or parethese](#243-line-breaks-may-occur-after-an-open-brace-bracket-or-parethese)
+        * [**2.4.4.** Line breaks may occur after an infix operator](#244-line-breaks-may-occur-after-an-infix-operator)
+        * [**2.4.5.** Line breaks may occur after the last expression in a list](#245-line-breaks-may-occur-after-the-last-expression-in-a-list)
+        * [**2.4.6.** Line breaks should not occur anywhere not mentioned in **2.4.**](#246-line-breaks-should-not-occur-anywhere-not-mentioned-in-24)
+    * [**2.2.** Blank lines](#22-blank-lines)
+        * [**2.2.1.** Source files should not begin with a blank line](#221-source-files-should-not-begin-with-a-blank-line)
+        * [**2.2.2.** Functions and methods should be padded by blank lines](#222-functions-and-methods-should-be-padded-by-blank-lines)
+        * [**2.2.3.** Function blocks should not contain blank lines](#223-function-blocks-should-not-contain-blank-lines)
+        * [**2.2.4.** Logical groups of imports should be padded by blank lines](#224-logical-groups-of-imports-should-be-padded-by-blank-lines)
+        * [**2.2.5.** Logical groups of class members should be padded by blank lines](#225-logical-groups-of-class-members-should-be-padded-by-blank-lines)
+    * [**2.5.** There should be a newline at the end of each source file](#25-there-should-be-a-newline-at-the-end-of-each-source-file)
+* [**3.** Punctuation](#3-punctuation)
+    * [**3.1.** Always use semicolons at the end of statements](#31-always-use-semicolons-at-the-end-of-statements)
+    * [**3.2.** Use trailing commas in multi-line lists](#32-use-trailing-commas-in-multi-line-lists)
+    * [**3.3.** Always enclose block statements within braces](#33-always-enclose-block-statements-within-braces)
+    * [**3.4.** Use parentheses generously when mixing infix operators](#34-use-parentheses-generously-when-mixing-infix-operators)
+    * [**3.5.** Arrow functions](#35-arrow-functions)
+        * [**3.5.1.** Prefer parentheses around arrow function parameters](#351-prefer-parentheses-around-arrow-function-parameters)
+        * [**3.5.2.** Prefer braces around arrow function bodies](#352-prefer-braces-around-arrow-function-bodies)
+    * [**3.6.** Strings](#36-strings)
+        * [**3.6.1.** Prefer double-quoted strings](#361-prefer-double-quoted-strings)
+        * [**3.6.2.** Use concatenation when writing long string literals](#362-use-concatenation-when-writing-long-string-literals)
+* [**4.** Comments](#4-comments)
+    * [**4.1.** Begin all comments with a single space](#41-begin-all-comments-with-a-single-space)
+    * [**4.2.** Prefer multiple single-line comments to multi-line block comments](#42-prefer-multiple-single-line-comments-to-multi-line-block-comments)
+    * [**4.3.** Prefer comments on their own line to trailing comments](#43-prefer-comments-on-their-own-line-to-trailing-comments)
+    * [**4.4.** Trailing comments should have one space between "//" and the end of the line](#44-trailing-comments-should-have-one-space-between--and-the-end-of-the-line)
+    * [**4.5.** Documenting comments](#45-documenting-comments)
+        * [**4.5.1.** Document all classes and interfaces](#451-document-all-classes-and-interfaces)
+        * [**4.5.2.** Document all functions and methods](#452-document-all-functions-and-methods)
+        * [**4.5.3.** Document the impure behavior of functions](#453-document-the-impure-behavior-of-functions)
+        * [**4.5.4.** Document all constants and enumerations](#454-document-all-constants-and-enumerations)
+        * [**4.5.6.** Document variables or attributes that are not completely self-explanatory](#456-document-variables-or-attributes-that-are-not-completely-self-explanatory)
+        * [**4.5.6.** Document statements or expressions that are not completely self-explanatory](#456-document-statements-or-expressions-that-are-not-completely-self-explanatory)
+    * [**4.6.** Todos](#46-todos)
+        * [**4.6.1.** Todo comments should begin with "// TODO:"](#461-todo-comments-should-begin-with--todo)
+        * [**4.6.2.** Todo comments should include an explanation of the unfinished task](#462-todo-comments-should-include-an-explanation-of-the-unfinished-task)
+        * [**4.6.3.** Todo comments should include the URL for a relevant issue or PR](#463-todo-comments-should-include-the-url-for-a-relevant-issue-or-pr)
+* [**5.** Names](#5-names)
+    * [**5.1.** Use descriptive names](#51-use-descriptive-names)
+    * [**5.2.** Do not use needless or unconventional abbreviations](#52-do-not-use-needless-or-unconventional-abbreviations)
+    * [**5.3.** Names should contain only "A"-"Z", "a"-"z", and "0"-"9"](#53-names-should-contain-only-a-z-a-z-and-0-9)
+    * [**5.4.** Classes and constants should have PascalCase names](#54-classes-and-constants-should-have-pascalcase-names)
+    * [**5.5.** Functions and variables should have camelCase names](#55-functions-and-variables-should-have-camelcase-names)
+    * [**5.6.** TypeScript source files should have camelCase names](#56-typescript-source-files-should-have-camelcase-names)
+    * [**5.7.** Single-character names](#57-single-character-names)
+        * [**5.7.1.** Parameters with very clear purpose may be named "a", "b", "c", and so on](#571-parameters-with-very-clear-purpose-may-be-named-a-b-c-and-so-on)
+        * [**5.7.2.** The interpolant parameter should be named "t"](#572-the-interpolant-parameter-should-be-named-t)
+        * [**5.7.3.** Extremely generic type parameters may be named "T"](#573-extremely-generic-type-parameters-may-be-named-t)
+        * [**5.7.4.** Coordinates should be named "x", "y", "z", and "w"](#574-coordinates-should-be-named-x-y-z-and-w)
+        * [**5.7.5.** Vector components should be named "ijk" or "xyzw"](#575-vector-components-should-be-named-ijk-or-xyzw)
+        * [**5.7.6.** Single-character names should not be used except as mentioned in **5.7.**](#576-single-character-names-should-not-be-used-except-as-mentioned-in-57)
+* [**6.** Syntax conventions](#6-syntax-conventions)
+    * [**6.1.** Do not use "eval" or the function constructor](#61-do-not-use-eval-or-the-function-constructor)
+    * [**6.2.** Do not use "var"](#62-do-not-use-var)
+    * [**6.3.** Prefer "const" to "let" when declaring variables](#63-prefer-const-to-let-when-declaring-variables)
+    * [**6.4.** Do not use undeclared variables](#64-do-not-use-undeclared-variables)
+    * [**6.5.** Use seperate declarations](#65-use-seperate-declarations)
+    * [**6.6.** Prefer "if" and "else if" over "switch" and "case"](#66-prefer-if-and-else-if-over-switch-and-case)
+    * [**6.7.** Do not nest ternary expressions](#67-do-not-nest-ternary-expressions)
+    * [**6.8.** Prefer strict equality over regular equality](#68-prefer-strict-equality-over-regular-equality)
+    * [**6.9.** Prefer "as" when writing type assertions](#69-prefer-as-when-writing-type-assertions)
+    * [**6.10.** Prefer Type[] to Array](#610-prefer-type-to-array)
+    * [**6.11.** Do not refer to the "arguments" object](#611-do-not-refer-to-the-arguments-object)
+    * [**6.12.** Prefer rest parameters over referring to the "arguments" object](#612-prefer-rest-parameters-over-referring-to-the-arguments-object)
+    * [**6.13.** Avoid the spread operator in array and object literals](#613-avoid-the-spread-operator-in-array-and-object-literals)
+    * [**6.14.** Do not mix full object properties with shorthand properties](#614-do-not-mix-full-object-properties-with-shorthand-properties)
+    * [**6.15.** Imports](#615-imports)
+        * [**6.15.1.** Imports belong at the beginning of a source file](#6151-imports-belong-at-the-beginning-of-a-source-file)
+        * [**6.15.2.** Prefer selective imports over default imports](#6152-prefer-selective-imports-over-default-imports)
+        * [**6.15.3.** Prefer absolute over relative imports](#6153-prefer-absolute-over-relative-imports)
+        * [**6.15.4.** Group and order imports logically, then alphabetically by filename](#6154-group-and-order-imports-logically-then-alphabetically-by-filename)
+        * [**6.15.5.** Do not include unused imports](#6155-do-not-include-unused-imports)
+        * [**6.15.6.** Avoid importing modules for side-effects only](#6156-avoid-importing-modules-for-side-effects-only)
+    * [**6.16.** Ordering of class members](#616-ordering-of-class-members)
+        * [**6.16.1.** Declare static attributes first](#6161-declare-static-attributes-first)
+        * [**6.16.2.** Declare instance attributes second](#6162-declare-instance-attributes-second)
+        * [**6.16.3.** Declare the constructor third](#6163-declare-the-constructor-third)
+        * [**6.16.4.** Declare static member functions fourth](#6164-declare-static-member-functions-fourth)
+        * [**6.16.5.** Declare instance methods last](#6165-declare-instance-methods-last)
+* [**7.** Program logic conventions](#7-program-logic-conventions)
+    * [**7.1.** Prefer local state over global state](#71-prefer-local-state-over-global-state)
+    * [**7.2.** Prefer immutable state over mutable state](#72-prefer-immutable-state-over-mutable-state)
+    * [**7.3.** Prefer pure functions over impure functions](#73-prefer-pure-functions-over-impure-functions)
+    * [**7.4.** Functions should not modify their inputs](#74-functions-should-not-modify-their-inputs)
+    * [**7.5.** Class getters should treat the instance as logically const](#75-class-getters-should-treat-the-instance-as-logically-const)
+    * [**7.6.** Prefer template strings over concatenation](#76-prefer-template-strings-over-concatenation)
+    * [**7.7.** Prefer joining over repeated concatenation](#77-prefer-joining-over-repeated-concatenation)   
 
 
-# Formatting
 
-## Indent using four spaces
+## 1. Whitespace
 
-Code in jsdoom is indented with four spaces. The line followed by an open brace `{` should be indented one level further than the line with the open brace. The line with the corresponding closing brace `}` should be indented one level less.
+The following guidelines mainly pertain to the use of whitespace in code.
+
+### 1.1. Indent using four spaces
+
+Code is indented using four space characters.
+Do not indent with tab characters.
 
 ``` ts
 // [Comment explaining the purpose of my function]
@@ -31,9 +153,18 @@ function myFunction(): void {
 }
 ```
 
-## No double indents or partial indents
+### 1.2. Do not use double indents
 
-Code should be styled in such a way that each line is indented at either the same level as the last line, one more level, or one less. There should never be a jump of two or more indentation levels between lines. There should never be a partial change in indentation, e.g. one line should not be indented three spaces further than the next.
+Indentation must be in such a way that each line is indented at either the
+same level as the last line, one more level, or one less.
+There should never be a jump of two or more indentation levels between lines.
+
+In general, longer expressions made up of chained function calls should be
+broken across lines by using several shorter statements with intermediate
+assignments, or by putting the code inside a pair of paretheses `()` etc.
+on a new, idented line.
+They should _not_ be broken across lines by starting each line with the
+right-hand part of a member access, e.g. having a line begin with `.map(...)`.
 
 ``` ts
 myArray.map((value) => {
@@ -43,9 +174,77 @@ myArray.map((value) => {
 });
 ```
 
-## Whitespace around braces
+### 1.3. Do not use partial indents
 
-Open braces `{` should always be followed by a newline and close braces `}` should always be preceded by a newline. Open braces `{` generally should _not_ be preceded by a newline.
+There should never be a partial change in indentation.
+All changes in indentation from one line to the next should always be
+in multiples of four space characters.
+
+### 1.4. Whitespace as it pertains to braces, brackets, and paretheses
+
+The following guidelines mainly pertain to how whitespace should be
+used around braces `{}`, square brackets `[]`, angle brackets `<>`, and
+parentheses `()`.
+
+#### 1.4.1. No characters inside empty literals, blocks, or expressions
+
+Where an open brace `{`, parenthese `(`, etc. is followed by a corresponding
+closing brace `}`, parenthese `)`, etc. with no code in between, there should
+not generally be any whitespace, comments, or other characters in between
+those open and closing characters.
+
+``` ts
+const myEmptyObject: Object = {};
+```
+
+``` ts
+const myEmptyArray: number[] = [];
+```
+
+``` ts
+myFunctionInvokedWithNoArguments();
+```
+
+``` ts
+// [Comment explaining the purpose of my unconventional loop with no body]
+while(myIndex++ < myMaximumIndex){}
+```
+
+#### 1.4.2. Nested code should be indented at one additional level
+
+Where a statement is spread across multiple lines, the lines between a
+corresponding pair of braces `{}`, paretheses `()`, square brackets `[]`,
+or angle brackets `<>` should be indented at one additional level.
+
+``` ts
+const myMultiLineObjectLiteral: Object = {
+    myFirstAttribute: 1,
+    mySecondAttribute: 2,
+};
+```
+
+``` ts
+const myMultiLineExpression: boolean = (
+    myFirstCondition &&
+    mySecondCondition
+);
+```
+
+``` ts
+const myMultiLineArrayLiteral: string[] = [
+    "Hello world",
+    "How are you?",
+];
+```
+
+#### 1.4.3. Code within braces should not be in-line
+
+Open braces `{` should always be followed by a newline and close braces `}`
+should always be preceded by a newline.
+The code in between corresponding braces should be indented at one level
+further than the lines containing those braces.
+In general, an open brace `{` should not be immediately followed by any
+character other than a corresponding closing brace `}` or a newline `\n`.
 
 ``` ts
 const myObject: Object = {
@@ -55,21 +254,19 @@ const myObject: Object = {
 };
 ```
 
-Open braces `{` should generally be on the same line as the statement they pertain to.
+#### 1.4.4. Do not put open braces on their own line
 
-``` ts
-while(myCondition){
-    if(myOtherCondition){
-        doStuff();
-    }else{
-        doOtherStuff();
-    }
-}
-```
+Open braces `{` generally should _not_ be preceded by a newline.
+Open braces `{` should generally be on the same line as the statement or
+expression that they are a part of.
 
-## Do not pad enclosed expressions with spaces
+#### 1.4.5. Do not pad code between paretheses or brackets
 
-Except for where an expression is distributed across several lines due to its length, expressions or blocks inside paretheses `()`, square brackets `[]`, or angle brackets `<>` should not have spaces in between the opening bracket or parenthese and the first character of the enclosed expression, nor in between the closing bracket or parenthese and the final character of the enclosed expression.
+Except for where an expression is distributed across several lines due to its
+length, expressions or blocks inside paretheses `()`, square brackets `[]`,
+or angle brackets `<>` should not have spaces in between the opening character
+and the first character of the enclosed expression, nor in between the closing
+character and the final character of the enclosed expression.
 
 ``` ts
 // No space in between `[` and `1`.
@@ -84,59 +281,270 @@ const myArrayTooLongToFitOnOneLine = [
 ];
 ```
 
-## Put a newline at the end of files
+### 1.5. Use a single space after colons but no whitespace before
 
-In general, source files should terminate with a newline character `\n`.
-
-## Keep lines at or under eighty characters
-
-In general, no one line of code should exceed 80 characters. Where it is at all possible, lines should absolutely not exceed 100 characters in length.
+In objects and in typed declarations, there should be a single space after each
+colon `:` and no space before it.
 
 ``` ts
-const myLongExpressionResult: string = (
-    "This code statement is written in such a way that the line length " +
-    "consistently stays under eighty characters long. " +
-    "This line length limit particularly helps to accomodate those who " +
-    "are limited to smaller screens, or who subscribe to the rather " +
-    "common practice of displaying code from different source locations " +
-    "in two or more columns across a larger screen."
-);
+const myObject: Object {
+    myAttribute: "hello world",
+};
 ```
 
-## Always use semicolons
+### 1.5. Use whitespace after commas but not before
 
-Always put a semicolon `;` at the end of each statement. There should not be any whitespace in between the last character on the line and its terminating semicolon.
+In comma-separated lists, there should be whitespace after each comma `,`
+and no space before it.
+
+If the next item in a list after a given comma appears on the same line,
+then there should be a single space in beween the comma and the following
+non-whitespace character.
+If the next item in the list appears on the following line, then there should
+be a newline immediately after the comma and the next list item should be
+indented at the appropriate level.
 
 ``` ts
-doStuff();
+const myArray: number[] = [1, 2, 3, 4];
 ```
 
-## Commas belong immediately after the left-hand expression
-
-Commas `,` belong on the same line as the left-hand expression, with no space in between the comma and the last character of the expression.
-The first non-whitespace character of any line of code should never be a comma.
-Commas belong at the end of a line, not at the beginning.
-
 ``` ts
-const myArray: string[] = ["Hello", "World"];
-```
-
-## Use trailing commas in multi-line lists
-
-Always put a trailing comma `,` at the end of multi-line lists, where they are syntactically valid.
-
-``` ts
-const myArray: number[] = [
-    0x1000,
-    0x2000,
-    0x4000,
-    0x8000,
+const myMultiLineArray: string[] = [
+    "Hello",
+    "World",
 ];
 ```
 
-## Always enclose block statements within braces
+### 1.6. Infix operators
 
-All block statements should be enclosed within braces `{}`, i.e. single-line conditionals or loops without braces around their bodies should not generally be used.
+The following guidelines mainly pertain to the use of whitespace around
+infix operators, e.g. `+` or `*`.
+
+### 1.6.1. Put a single space between an infix operator and its left operand
+
+Infix operators should appear on the same line as the last character of their
+left operand. They should be separated from the last non-whitespace character
+of that left operand by a single space character.
+
+### 1.6.2. Put whitespace between an infix operator and its right operand
+
+An infix operator should have either a single space separating it from the
+first non-whitespace character of its right operand, or it should be
+immediately followed by a newline with the right operand placed at the correct
+indentation level on the next line.
+
+``` ts
+const mySum: number = 100 + 200;
+```
+
+``` ts
+const myMultiLineExpression: boolean = (
+    myFirstCondition ||
+    mySecondCondition
+);
+```
+
+
+
+
+## 2. Newlines
+
+The following guidelines mainly pertain to the placement of new lines and
+blank lines in code.
+
+### 2.1. Lines should not exceed eighty characters
+
+In general, no one line of code should exceed 80 characters.
+Please consider eighty characters to be a soft limit and one hundred characters
+to be a hard length limit.
+
+### 2.4. Line breaks
+
+The following guidelines mainly pertain to where line breaks should appear
+in code.
+
+#### 2.4.1. Line breaks should always occur after a semicolon
+
+Semicolons terminating a statement should be immediately followed by a
+newline. Two statements should not appear on the same line.
+
+``` ts
+const myFirstDeclaration: number = 1;
+const mySecondDeclaration: number = 2;
+```
+
+#### 2.4.2. Line breaks may occur after a comma
+
+Long lists of arguments, parameters, attributes, or other comma-separated
+lists may be broken up by placing newlines after the commas.
+
+In general, either all of the commas in a list should be followed by
+newlines or none of them should be.
+
+``` ts
+const myMultiLineArray: number[] = [
+    0x0100,
+    0x0200,
+    0x0400,
+];
+```
+
+#### 2.4.3. Line breaks may occur after an open brace, bracket, or parethese
+
+The code in between braces, brackets, etc. may appear on separate lines
+and be indented at one additional level.
+
+#### 2.4.4. Line breaks may occur after an infix operator
+
+It is appropriate for a line break to appear after an infix operator and
+before its right operand.
+
+``` ts
+const myMultiLineExpression: boolean = (
+    myFirstCondition ||
+    mySecondCondition
+);
+```
+
+#### 2.4.5. Line breaks may occur after the last expression in a list
+
+The last character of a multi-line list should normally be a trailing comma.
+However, in the case that the list appears on one line yet not on the same
+line as the closing bracket `]` or other character, it is appropriate for
+a line break to appear after the last item in the list.
+
+``` ts
+const myValue: number = myMultiLineFunctionInvocation(
+    100, 200, 300, 400, 500, 600
+);
+```
+
+#### 2.4.6. Line breaks should not occur anywhere not mentioned in 2.4.
+
+In general, line breaks on lines containing code should not occur under
+circumstances other than the ones explicitly mentioned above.
+
+Comments may exceptionally appear in between a character that would normally
+precede a line break and the terminating newline.
+However, this style of comments is not encouraged.
+In general, comments should appear on their own lines and not at the end
+of a line of code. (See `4.3.`.)
+
+### 2.2. Blank lines
+
+The following guidelines mainly specifically to the placement of blank lines.
+A blank line is a line which contains no characters or which contains
+only whitespace characters.
+
+#### 2.2.1. Source files should not begin with a blank line
+
+The first line in a source file should not be a blank line.
+
+#### 2.2.2. Functions and methods should be padded by blank lines
+
+In general, function or method declarations should be padded on each side
+by a single blank line, except for where the immediately previous or following
+line is the first line of the class declaration containing a method, or the
+line containing a class declaration's closing brace `}`.
+
+This does _not_ apply to helper functions that are declared inside another
+function. In general, function blocks should not contain blank lines, not
+even to pad helper function declarations.
+
+``` ts
+// [Comment explaining the purpose of my function]
+function myFirstFunction(): void {
+    doStuff();
+}
+
+// [Comment explaining the purpose of my function]
+function mySecondFunction(): void {
+    doStuff();
+}
+
+// [Comment explaining the purpose of my function]
+function myThirdFunction(): void {
+    doStuff();
+}
+```
+
+``` ts
+class MyClass {
+    // [Comment explaining the purpose of my method]
+    myFirstMethod(): void {
+        doStuff();
+    }
+
+    // [Comment explaining the purpose of my method]
+    mySecondMethod(): void {
+        doStuff();
+    }
+    
+    // [Comment explaining the purpose of my method]
+    myThirdMethod(): void {
+        doStuff();
+    }
+}
+```
+
+#### 2.2.3. Function blocks should not contain blank lines
+
+In general, the implementation of a function or method should not contain
+blank lines.
+If a function is made up of several different conceptual units,
+then they should be separated by explanatory comments instead of separated
+by blank lines.
+If a function is too long or complex to be readable without those empty lines,
+then parts of the implementation should be moved into other helper functions.
+
+#### 2.2.4. Logical groups of imports should be padded by blank lines
+
+Logical groups of imports should be separated from each other by a single
+blank line.
+See `6.15.` for more information about how imports should be grouped.
+
+#### 2.2.5. Logical groups of class members should be padded by blank lines
+
+Logical groups of class members should be separated from each other by a single
+blank line.
+See `6.16.` for more information about how class members should be grouped.
+
+### 2.5. There should be a newline at the end of each source file
+
+TypeScript source files should terminate with a newline character `\n`.
+
+
+
+## 3. Punctuation
+
+The following guidelines mainly pertain to the use of punctuation characters
+in code.
+
+### 3.1. Always use semicolons at the end of statements
+
+Statements should always be terminated by a semicolon `;`.
+Do not trust JavaScript's automatic semicolon insertion to get it right.
+
+### 3.2. Use trailing commas in multi-line lists
+
+Where it is syntactically valid, the last item in a comma-separated list that
+spans more than one line should be followed by a comma `,`.
+
+``` ts
+const myMultiLineArray: number[] = [
+    0x0100,
+    0x0200,
+    0x0400,
+];
+```
+
+### 3.3. Always enclose block statements within braces
+
+Block statements such as the body of a loop or an `if` statement should
+always be enclosed within braces, even if it is syntactically valid to
+omit those braces.
+Single-line conditionals or loops without braces around their bodies should
+not generally be used.
 
 ``` ts
 if(myExitCondition){
@@ -150,60 +558,12 @@ while(myLoopCondition){
 }
 ```
 
-## Function blocks should not contain blank lines
+### 3.4. Use parentheses generously when mixing infix operators
 
-In general, the implementation of a function or method should not contain empty lines. If a function is made up of several different conceptual units, then they should be separated by explanatory comments instead of by empty lines. If a function is too long or complex to be readable without those empty lines, then parts of the implementation should be moved into other helper functions.
-
-``` ts
-// This is a helper function used by myVeryComplicatedProcedure.
-// [Comment explaining the first task]
-function doTheFirstTask(): void {
-    // Imagine this function body is 100 lines long!
-    doStuff();
-}
-
-// This is a helper function used by myVeryComplicatedProcedure.
-// [Comment explaining the second task]
-function doTheSecondTask(): void {
-    // Imagine this function body is 100 lines long!
-    doOtherStuff();
-}
-
-// This is a helper function used by myVeryComplicatedProcedure.
-// [Comment explaining the third task]
-function doTheThirdTask(): void {
-    // Imagine this function body is 100 lines long!
-    doYetMoreStuff();
-}
-
-// [Comment explaining the purpose of my very complicated function]
-// Imagine that this function body would be a dense, unreadable 300 lines
-// if it wasn't broken up into several helper function calls this way!
-function myVeryComplicatedProcedure(): void {
-    // [Comment briefly summarizing the first task]
-    doTheFirstTask();
-    // [Comment briefly summarizing the second task]
-    doTheSecondTask();
-    // [Comment briefly summarizing the third task]
-    doTheThirdTask();
-}
-```
-
-## Pad infix operators with spaces
-
-An infix operator should have whitespace separating it from both operands.
-
-``` ts
-const mySum: number = 100 + 200;
-```
-
-``` ts
-const myValue: number = myNumberArray[myIndex + 10];
-```
-
-## Use parentheses generously when mixing infix operators
-
-When a single expression contains several different infix operators, each group of identical operators should generally be enclosed within parentheses `()`. This helps to avoid any confusion or ambiguity regarding the intended order of operations.
+When a single expression contains several different infix operators, each group
+of identical operators should generally be enclosed within parentheses `()`.
+This helps to avoid any confusion or ambiguity regarding the intended order of
+operations.
 
 ``` ts
 const myValue: number = 10 * (20 + myOtherValue);
@@ -216,28 +576,55 @@ const myBoolean: boolean = (
 );
 ```
 
-## Use space after colons but not before
+### 3.5. Arrow functions
 
-In objects and in typed declarations, there should be a single space after each colon `:` and no space before it.
+The following guidelines mainly pertain to the use of punctuation characters
+as they apply to arrow functions.
+
+#### 3.5.1. Prefer parentheses around arrow function parameters
+
+In general, the parameter list of an arrow function should always be enclosed
+within paretheses `()`, even when there is only a single parameter.
 
 ``` ts
-const myObject: Object {
-    myAttribute: "hello world",
-};
+myArray.map((value) => {
+    return value + value;
+});
 ```
 
-## Prefer double-quoted strings
+#### 3.5.2. Prefer braces around arrow function bodies
 
-String literals should be double-quoted `""`. In general, they should not ever be single-quoted `''`.
-Template strings (enclosed within backticks ``` `` ```) should generally not be used for string literals that do not actually contain any interpolation.
+In general, the bodies of arrow functions should always be enclosed within
+braces `{}`, even when the function body contains only a `return` statement.
+
+``` ts
+myArray.filter((value) => {
+    return value > 0;
+});
+```
+
+### 3.6. Strings
+
+The following guidelines mainly pertain to the use of punctuation characters
+as they apply to string literals.
+
+#### 3.6.1. Prefer double-quoted strings
+
+String literals should be double-quoted `""`.
+In general, they should not ever be single-quoted `''`, even when the literal
+itself contains double quotes.
+
+Template strings (enclosed within backticks) should not be used for
+string literals that do not actually contain any interpolation.
 
 ``` ts
 const myString: string = "You say \"goodbye\" and I say \"hello\".";
 ```
 
-## Use concatenation when writing long string literals
+#### 3.6.2. Use concatenation when writing long string literals
 
-String literals that are too long to fit on a single line should be spread across multiple lines by concatenating many shorter string literals.
+String literals that are too long to fit on a single line should be spread
+across multiple lines by concatenating many shorter string literals.
 
 ``` ts
 const myLongStringLiteral = (
@@ -248,47 +635,26 @@ const myLongStringLiteral = (
 );
 ```
 
-## Prefer parentheses around arrow function parameters
 
-In general, the parameter list of an arrow function should always be enclosed within paretheses `()`.
 
-``` ts
-myArray.map((value) => {
-    return value + value;
-});
-```
+## 4. Comments
 
-## Prefer braces around arrow function bodies
+The following guidelines mainly pertain to what is expected of code comments.
 
-In general, the bodies of arrow functions should always be enclosed within
-braces `{}`.
+### 4.1. Begin all comments with a single space
 
-``` ts
-myArray.filter((value) => {
-    return value > 0;
-});
-```
-
-## Use seperate declarations
-
-Do not declare multiple variables together on the same line. Use separate declarations, with each declaration on its own line.
-
-``` ts
-const myFirstNumber: number = 0;
-const mySecondNumber: number = 0;
-```
-
-## Start all comments with a space
-
-In general, there should always be a single space character in between a comment's opening slashes `//` and the first character of the comment's text.
+There should be a single space character in between a comment's opening
+slashes `//` and the first character of the comment's text.
 
 ``` ts
 // Note the space at the beginning of this comment!
 ```
 
-## Prefer multiple single-line comments to multi-line block comments
+### 4.2. Prefer multiple single-line comments to multi-line block comments
 
-In general, long comments should be spread across multiple single line comments (i.e. `// comment`) rather than given in a single multi-line block comment (i.e. `/* comment */`).
+Long comments should be spread across multiple single line comments
+(i.e. `// comment`) rather than given in a single multi-line block comment
+(i.e. `/* comment */`).
 
 ``` ts
 // This is a longer comment providing a lot of information about a function.
@@ -299,39 +665,192 @@ function myFunction(value: number): number {
 }
 ```
 
-## Prefer comments on their own line to trailing comments
+### 4.3. Prefer comments on their own line to trailing comments
 
-In general, comments should be on their own line, preceding the code that they apply to, instead of on the same line, immediately after the code that they apply to.
+Comments should usually not be on the same line as code.
+Comments should be on their own line, preceding the code that they apply to.
 
 ``` ts
 // [Comment explaining the purpose of my variable]
 let myVariable: number = 0;
 ```
 
-## Prefer "as" to type assertions
+### 4.4. Trailing comments should have one space between "//" and the end of the line
 
-Prefer syntax such as `value as Type` over `<Type> value`.
-([Why?](https://stackoverflow.com/a/33503842/4099022))
+Note that `4.3.` discourages the use of trailing comments.
+When trailing comments _are_ used, there should always be exactly one space
+in between the last character of code and the first character `/` of the
+trailing comment.
 
 ``` ts
-const myValue: number = myOtherValue as number;
+doStuff(); // My trailing comment
 ```
 
-## Prefer Type[] to Array<Type>
-    
-Prefer type syntax such as `myArray: string[]` to `myArray: Array<string>`.
-    
+### 4.5. Documenting comments
+
+The following guidelines mainly pertain to when documenting comments are
+encouraged or required.
+
+#### 4.5.1. Document all classes and interfaces
+
+Every class and interface should have a comment explaining its purpose, even
+if it is only repeating information that should be self-evident.
+
 ``` ts
-const myStringArray: string[] = ["Hello", "World"];
+// This class stores the color channel information taken from a PLAYPAL
+// lump. Note that the color data is 24-bit. Color channel values should
+// always be in the range [0, 256] inclusive.
+class MyColorClass {
+    // The color's 8-bit red color channel.
+    red: number;
+    // The color's 8-bit green color channel.
+    green: number;
+    // The color's 8-bit blue color channel.
+    blue: number;
+}
+```
+
+#### 4.5.2. Document all functions and methods
+
+Every function or method should have a comment explaining its purpose, even
+if it is only repeating information that should be self-evident.
+
+``` ts
+// Log a friendly greeting to the console.
+function sayHello(): void {
+    console.log("Hello, world!");
+}
+```
+
+#### 4.5.3. Document the impure behavior of functions
+
+Functions and methods with impure behavior should have that impure behavior
+documented in comments to the greatest extent that is practical.
+
+Note that impure behavior includes modifying a function's inputs or
+reading or writing global state.
+
+``` ts
+// [Comment explaining the purpose of my function]
+// Calling this function will cause `myPreviouslyDeclaredGlobal`
+// to be modified.
+function myFunctionWithSideEffects(): void {
+    myPreviouslyDeclaredGlobal = doStuff();
+}
+```
+
+#### 4.5.4. Document all constants and enumerations
+
+Constants - defined as values set once and never reassigned, not necessarily
+any variable declared using `const` - should always be accompanied by a comment
+explaining their purpose and their value.
+
+``` ts
+// The Doom engine palette lump is always named "PLAYPAL".
+const PlaypalLumpName: string = "PLAYPAL";
+```
+
+Enumerations should be preceded by a documenting comment, and every member
+should have a comment explaining its purpose.
+
+``` ts
+// Enumeration of Doom linedef flags which pertain to texturing.
+enum LinedefTextureFlags {
+    // Unpegged upper texture
+    UpperUnpegged = 0x0008,
+    // Unpegged lower texture
+    LowerUnpegged = 0x0010,
+}
+```
+
+#### 4.5.6. Document variables or attributes that are not completely self-explanatory
+
+It is not necessary to write a comment explaining every variable or attribute,
+but those whose function is not immediately obvious from looking at the
+declaration should be accompanied by documentation comments.
+
+#### 4.5.6. Document statements or expressions that are not completely self-explanatory
+
+It is not necessary, and in fact discouraged, to write a comment explaining
+every statement and expression.
+However, those statements and expressions which are more complicated or with
+less obvious purpose should be accompanied by documentation comments.
+
+``` ts
+// Do stuff with the length of the vector described by (x, y).
+doStuffWith(Math.sqrt((x * x) + (y * y)));
+```
+
+### 4.6. Todos
+
+The following guidelines mainly pertain to how "TODO" comments should be used.
+
+#### 4.6.1. Todo comments should begin with "// TODO:"
+
+Comments recording future or unfinished tasks should consistently begin
+with the characters `// TODO: `.
+
+When a todo comment is too long to fit on a single line, only the first line
+explaining the task should be preceded by `TODO`.
+
+``` ts
+function myScaffoldingFunction(): void {
+    // TODO: Implement this function
+}
+```
+
+#### 4.6.2. Todo comments should include an explanation of the unfinished task
+
+It is not acceptable to write a todo comment without including some written
+explanation of the task that is not finished.
+Do not write a comment that says `// TODO` without being followed by more
+text explaining why the comment is present.
+
+#### 4.6.3. Todo comments should include the URL for a relevant issue or PR
+
+Where practical, todo comments should refer to an issue in the issue tracker,
+or to a relevant pull request.
+In general, if such a relevant issue or other link does not exist, then it
+should be created and referenced in the todo comment before the comment is
+included in the master branch of the code repository
+
+``` ts
+// TODO: Create a help page and assign the URL.
+// See https://github.com/pineapplemachine/jsdoom/issues/123456
+const myHelpUrl: string = "";
 ```
 
 
 
-# Naming
+## 5. Names
 
-## Characters allowed in identifiers
+The following guidelines mainly pertain to the naming of variables,
+classes, etc. and source file names.
 
-In general, dentifiers should be made up only of the characters `A` through `Z`, `a` through `z`, and `0` through `9`. Identifiers generally should not have an underscore `_` in their name, even if they identify private members.
+### 5.1. Use descriptive names
+
+All classes, functions, variables etc. should be assigned descriptive names
+that make their purpose as clear as possible.
+Avoid using vague or generic names that do not communicate purpose.
+
+### 5.2. Do not use needless or unconventional abbreviations
+
+Identifiers should generally not contain abbreviations unless those
+abbreviations are essentially universal and/or the text that they are
+abbreviating is impractically long to actually include in code.
+
+"HTML" abbreviating "HypertextMarkupLanguage" or "WAD" abbreviating
+"WheresAllTheData" is good and encouraged.
+However, "Idx" abbreviating "Index" or "Err" abbreviating "Error" is not
+acceptable. Please use common sense in judging whether an abbreviation is
+really necessary, and whether it might make the code more difficult to read.
+
+### 5.3. Names should contain only "A"-"Z", "a"-"z", and "0"-"9"
+
+Identifiers should be made up only of the characters `A` through `Z`,
+`a` through `z`, and `0` through `9`.
+Identifiers should not have an underscore `_` in their name, even if they
+identify private members.
 
 Do not use characters such as emoji or math symbols in variable names.
 
@@ -339,118 +858,26 @@ Do not use characters such as emoji or math symbols in variable names.
 const myAsciiVariableName: number = 0;
 ```
 
-## Use descriptive names
+### 5.4. Classes and constants should have PascalCase names
 
-Functions, classes, variables, and other named entities should have informative, descriptive names. Names should generally not contain abbreviations.
+Class and interface names names, constructors, enumerations, and the names of
+constants should be written in PascalCase.
 
-"HTML" abbreviating "HypertextMarkupLanguage" or "WAD" abbreviating "WheresAllTheData" is okay and encouraged, but "Idx" abbreviating "Index" or "Err" abbreviating "Error" is not okay. Please use common sense in judging whether an abbreviation is really necessary, and whether it might make the code more difficult to read.
+Note that constant in this case does not mean everything declared using `const`,
+but rather it refers to any variable that is initialized once and never changed
+during program execution.
+Constants are not a matter of syntax in TypeScript, but a matter of intent.
 
-Single-letter identifiers are strictly disallowed with the exception
-of `x`, `y`, `z`, `w`, `i`, `j`, and `k` where they are specifically used to
-describe position or vector components,
-`t` where used to name the [interpolant parameter of an interpolation function](https://en.wikipedia.org/wiki/Linear_interpolation),
-or `a`, `b`, `c`, etc. where they are used to name the parameters of a function
-with very clear inputs and purpose.
+### 5.5. Functions and variables should have camelCase names
 
-To summarize: Single-character identifiers should be used when it follows a long-standing mathematical convention (`x`, `y`, `t`, etc.), or when used to describe a sequence of parameters where sequential single-character identifiers represent a clear and prevalent naming convention (`a`, `b`, `c`, etc.). Single-character identifiers should not generally be used otherwise.
+Names of functions, methods, variables, attributes, function parameters,
+and anything else that is not mentioned by `5.4.` should be written
+using camelCase.
 
-``` ts
-// [Comment explaining the purpose of my vector class]
-class MyVector {
-    x: number;
-    y: number;
-    z: number;
-}
-```
+### 5.6. TypeScript source files should have camelCase names
 
-``` ts
-// Linearly interpolate between the numbers "a" and "b".
-// The value "t" should normally be in the inclusive range [0.0, 1.0].
-function lerp(a: number, b: number, t: number): Vector {
-    return (a * (1 - t)) + (b * t);
-}
-```
-
-``` ts
-// Note that `a` and `b` are acceptable parameter names for
-// comparator functions, even though single-character variable names
-// generally are not allowed.
-myArray.sort((a: number, b: number) => {
-    return a - b;
-});
-```
-
-Except for describing the ordering of color channels, e.g. `RGBA` or `ARGB`, do not abbreviate `red` as `r`, `green` as `g`, `blue` as `b`, or `alpha` as `a`.
-Instead, write out the full names of each color channel.
-
-``` ts
-// [Comment explaining the purpose of my interface]
-// Note that each channel attribute is fully written out and not abbreviated.
-interface MyColorInterface {
-    red: number;
-    green: number;
-    blue: number;
-    alpha: number;
-}
-```
-
-Do not assign loop variables single-character names such as `x` or `i` if
-the value does not literally correspond to a position or to a vector component.
-Use descriptive names for loop variables instead, and prefer more descriptive
-identifiers like `vectorIndex` over less descriptive identifiers like `index`.
-
-``` ts
-for(let vectorIndex: number = 0; vectorIndex < totalVectors; vectorIndex++){
-    const myVector: Vector = vectors[vectorIndex];
-    doStuffWithVector(myVector);
-}
-```
-
-## Use PascalCase for classes and constants
-
-Class names, constructors, and the names of constants should be written in PascalCase.
-Note that constant in this case does not mean everything declared using `const`, but rather it refers to any variable that is initialized once and never changed during program execution. (Constants are not a matter of syntax in TypeScript, but a matter of intent.)
-
-``` ts
-// [Comment explaining the purpose of my constant]
-const PlaypalLumpName = "PLAYPAL";
-```
-
-``` ts
-// [Comment explaining the purpose of my class]
-class MyClass {
-    // [Comment explaining the purpose of my attribute]
-    myAttribute: string;
-}
-```
-
-## Use camelCase for functions and variables
-
-Names of functions, methods, variables, attributes, and function parameters should be written in camelCase.
-
-``` ts
-// [Comment explaining the usage of this function]
-function getPaletteCount(): number {
-    return 100;
-}
-```
-
-``` ts
-// [Comment explaining the purpose of my class]
-class MyClass {
-    // [Comment explaining the purpose of my attribute]
-    myAttribute: string;
-    
-    // [Comment explaining why this class has a number-squaring helper]
-    mySquaringMethod(value: number): number {
-        return value * value;
-    }
-}
-```
-
-## Use camelCase for TypeScript source file names
-
-TypeScript source files should be assigned pascalCase names.
+TypeScript source files and directories containing TypeScript source files
+should be assigned pascalCase names.
 
 ``` text
 - file.ts
@@ -458,20 +885,120 @@ TypeScript source files should be assigned pascalCase names.
 - fileType.ts
 ```
 
+### 5.7. Single-character names
 
-# Conventions
+The following guidelines mainly pertain to the use of single-character names.
+Single-character names are mostly discouraged, but are still the most
+appropriate naming choice for some cases.
 
-## Do not use "eval" or the function constructor
+#### 5.7.1. Parameters with very clear purpose may be named "a", "b", "c", and so on
 
-Do not ever use the `eval` built-in function. Do not ever use the `Function` constructor to create a new function. These are inefficient and would make jsdoom vulnerable to arbitrary code execution.
+Sequential single-letter identifiers such as `a`, `b`, `c`, and so on are
+acceptable where they are used to name the parameters of a function with very
+clear inputs and purpose, where those inputs are mainly distinguished by
+the order in which they appear.
 
-## Do not use "var"
+``` ts
+// `a` and `b` are the preferred parameter names for comparator functions.
+myArray.sort((a: number, b: number) => {
+    return a - b;
+});
+```
 
-Do not declare variables using `var`. Use `let` or `const` instead.
+#### 5.7.2. The interpolant parameter should be named "t"
 
-## Prefer "if" and "else if" over "switch" and "case"
+Where a parameter or other named value is used as the
+[interpolant parameter of an interpolation function](https://en.wikipedia.org/wiki/Linear_interpolation),
+that value should be named `t`.
 
-In general, a series of `if` and `else if` statements should be used instead of a `switch` statement.
+``` ts
+// Linearly interpolate between the numbers `a` and `b`.
+// The value `t` should normally be in the inclusive range [0.0, 1.0].
+function lerp(a: number, b: number, t: number): Vector {
+    return (a * (1 - t)) + (b * t);
+}
+```
+
+#### 5.7.3. Extremely generic type parameters may be named "T"
+
+A generic function or class accepting a single type parameter may have
+that parameter named `T` if the purpose of the parameter is generic enough
+to not lend itself to a more descriptive name.
+
+#### 5.7.4. Coordinates should be named "x", "y", "z", and "w"
+
+The single-character names `x`, `y`, `z`, and `w` are acceptable and encouraged
+when they refer to spatial coordinates along the corresponding axes.
+
+#### 5.7.5. Vector components should be named "ijk" or "xyzw"
+
+The components of vectors or quaternions should normally be named
+either `i`, `j`, `k` or `x`, `y`, `z`, `w`.
+
+``` ts
+// [Comment explaining the purpose of my three-dimensional vector class]
+class MyVector {
+    x: number;
+    y: number;
+    z: number;
+}
+```
+
+#### 5.7.6. Single-character names should not be used except as mentioned in 5.7.
+
+Except as otherwise mentioned above in `5.7.`, single-character names should
+not normally be used.
+
+Here is a rule of thumb: Single-character identifiers should only be used when
+it follows a long-standing mathematical or programming convention, such that
+choosing any other name may make the purpose of the variable, etc. less clear.
+
+
+
+## 6. Syntax conventions
+
+The following guidelines mainly pertain to what TypeScript syntax options should
+be favored or avoided.
+
+### 6.1. Do not use "eval" or the function constructor
+
+Do not use the `eval` built-in function.
+Do not use the `Function` constructor to create a new function.
+This functionality is not efficient and it opens the door to security issues.
+
+### 6.2. Do not use "var"
+
+Do not use `var` when declaring variables. Use `let` or `const` instead.
+
+``` ts
+const myVariable: number = 0;
+```
+
+### 6.3. Prefer "const" to "let" when declaring variables
+
+Use `const` instead of `let` whenever it is syntactically valid, i.e. when the
+declared reference is never changed.
+
+### 6.4. Do not use undeclared variables
+
+Do not use variables without declaring them.
+Do not reference variables that have not yet been declared at the time
+that the code will be executed.
+
+### 6.5. Use seperate declarations
+
+Do not declare multiple variables together on the same line.
+Use separate declarations, with each declaration on its own line.
+
+``` ts
+const myFirstNumber: number = 0;
+const mySecondNumber: number = 0;
+```
+
+### 6.6. Prefer "if" and "else if" over "switch" and "case"
+
+Prefer using a series of `if` and `else if` statements instead of using a
+`switch` statement.
 
 ``` ts
 if(myVariable === 0){
@@ -485,37 +1012,263 @@ if(myVariable === 0){
 }
 ```
 
-## Do not nest ternary expressions
+### 6.7. Do not nest ternary expressions
 
-In general, ternary expressions `a ? b : c` should not be nested.
+Ternary expressions `a ? b : c` should not be nested.
 
-## Prefer strict equality over regular equality
+### 6.8. Prefer strict equality over regular equality
 
-The equality operator `==` and inequality operator `!=` should not generally be used. Prefer the strict equality operator `===` and strict inequality operator `!==` instead.
+The strict equality `===` and strict inequalty `!==` operators should be
+used instead of the regular equality `==` and inequality `!=` operators.
 
 ``` ts
 const myComparison: boolean = (myFirstValue === mySecondValue);
 ```
 
-## Prefer local state over global state
+### 6.9. Prefer "as" when writing type assertions
 
-Code which relies on local state is easier to understand and maintain than code which relies on global state.
-It is not possible to completely avoid global state, particularly in code that deals with the DOM. However, global state should be avoided when possible. State should instead be stored locally in scoped variables or class instances.
+When writing a type assertion, prefer syntax like `value as Type` over
+syntax like `<Type> value`. ([Why?](https://stackoverflow.com/a/33503842/4099022))
 
 ``` ts
-const myConstantVariable: number = 0;
-let myMutableVariable: number = 0;
+const myValue: number = myOtherValue as number;
 ```
 
-## Prefer immutable state over mutable state
+### 6.10. Prefer Type[] to Array<Type>
 
-Use `const` instead of `let` for references which are not changed.
+When describing an array type, prefer syntax like `Type[]` to syntax like
+`Array<Type>`.
+    
+``` ts
+const myStringArray: string[] = ["Hello", "World"];
+```
 
-Where it will not substantially impact performance in a negative way, treat variables and objects as immutable.
+### 6.11. Do not refer to the "arguments" object
 
-## Prefer pure functions over impure functions
+Functions should not refer to the `arguments` object.
 
-Pure functions are those which accept inputs and return an output without making any changes to the inputs and without producing any side-effects. In essence, a pure function is one which can be called at any time, any number of times, and the same inputs will always produce the same output.
+### 6.12. Prefer rest parameters over referring to the "arguments" object
+
+Functions which accept a variable number of arguments should do so using a
+rest parameter `...` and not by accessing the `arguments` object.
+
+``` ts
+// [Comment explaining the purpose of my function]
+function myVariadicFunction(...strings: string[]): void {
+    doStuffWithList(strings);
+}
+```
+
+### 6.13. Avoid the spread operator in array and object literals
+
+Prefer using functions like `Array.concat` or `Object.assign` over using
+the spread operator to construct arrays or objects.
+
+``` ts
+// Use `Array.concat` instead of the spread operator
+const myConcatenatedArray = (
+    myFirstArray.concat(mySecondArray)
+);
+```
+
+``` ts
+// Assign each key individually or, if the keys are numerous or not
+// necessarily known ahead of time, use `Object.assign` instead of
+// using the spread operator.
+const myComposedObject = {};
+Object.assign(myComposedObject, myFirstObject, mySecondObject);
+```
+
+### 6.14. Do not mix full object properties with shorthand properties
+
+An object should either use only shorthand properties or only full properties.
+A single object literal should not mix both types of properties.
+
+``` ts
+const myObjectWithFullProperties: Object = {
+    firstValue: firstValue,
+    secondValue: secondValue,
+};
+```
+
+``` ts
+const myObjectWithShortProperties: Object = {
+    firstValue,
+    secondValue,
+};
+```
+
+### 6.15. Imports
+
+The following guidelines mainly pertain to how imports should be written.
+
+#### 6.15.1. Imports belong at the beginning of a source file
+
+Import statements should be at the very top of a TypeScript source file.
+They should not appear anywhere else.
+
+#### 6.15.2. Prefer selective imports over default imports
+
+Prefer selective imports (imports with braces `{}`) over default imports
+(imports without braces).
+
+``` ts
+import {WADFile} from "@src/wad/file";
+```
+
+However, modules should still have a default export where it makes
+sense to choose a default.
+
+``` ts
+// Actual export from "@src/wad/file"
+export default WADFile;
+```
+
+#### 6.15.3. Prefer absolute over relative imports
+
+Absolute import paths (those starting with an "at" sign `@`) should be
+preferred over relative paths (those starting with a dot `.`).
+Note that the meaning of these absolute paths are defined by macros in the
+TypeScript config file `tsconfig.json` and the webpack config
+file `webpack.config.js`.
+
+``` ts
+import {WADFile} from "@src/wad/file";
+```
+
+#### 6.15.4. Group and order imports logically, then alphabetically by filename
+
+Imports should first be ordered by logical group, and then alphabetically by
+filename.
+Groups should generally be ordered from most general to most specialized.
+Here is a guideline for how to separate and order these groups:
+
+1. Native dependencies, such as Node.js imports.
+2. External dependencies, i.e. those listed in `package.json`.
+3. Jsdoom library dependencies, e.g. `@src/wad/` or `@src/lumps/`.
+4. Jsdoom UI or engine dependencies, e.g. `@web/`.
+
+``` ts
+import * as fs from "fs";
+import * as path from "path";
+
+import * as UPNG from "upng-js";
+
+import {WADFile} from "@src/wad/file";
+import {WADFileList} from "@src/wad/fileList";
+
+import {LumpTypeView} from "@web/lumpTypeView";
+```
+
+#### 6.15.5. Do not include unused imports
+
+Avoid importing unused symbols or modules.
+
+#### 6.15.6. Avoid importing modules for side-effects only
+
+Avoid writing side-effect-only import statements, i.e. statements
+such as `import "module";`.
+
+### 6.16. Ordering of class members
+
+The following guidelines mainly pertain to how class member declarations
+should be ordered.
+
+#### 6.16.1. Declare static attributes first
+
+Static attributes and constants should come before all other declarations
+in a class.
+
+``` ts
+class MyClass {
+    // [Comment explaining the purpose of my constant]
+    static readonly MyStaticConstant: number = 0x8000;
+}
+```
+
+#### 6.16.2. Declare instance attributes second
+
+Instance attributes should be declared after static attributes but before the
+constructor and any member functions or methods.
+
+``` ts
+class MyClass {
+    // [Comment explaining the purpose of my attribute]
+    myFirstAttribute: string;
+    // [Comment explaining the purpose of my attribute]
+    mySecondAttribute: string;
+}
+```
+
+#### 6.16.3. Declare the constructor third
+
+The class constructor should come after all static and instance attribute
+declarations but before all method and member function declarations.
+
+``` ts
+class MyClass {
+    constructor() {
+        this.myFirstAttribute = "hello";
+        this.mySecondAttribute = "world";
+    }
+}
+```
+
+#### 6.16.4. Declare static member functions fourth
+
+Static member functions should appear after attribute declarations and
+after the class constructor, but before instance method declarations.
+
+``` ts
+class MyClass {
+    // [Comment explaining the purpose of my function]
+    static myStaticFunction(): MyClass {
+        return new MyClass();
+    }
+}
+```
+
+#### 6.16.5. Declare instance methods last
+
+Instance methods should appear after all other declarations in a class.
+
+``` ts
+class MyClass {
+    // [Comment explaining the purpose of my method]
+    getTotalLength(): number {
+        return this.myFirstAttribute.length + this.mySecondAttribute.length;
+    }
+}
+```
+
+
+
+## 7. Program logic conventions
+
+The following guidelines mainly pertain to the use of consistent logic and design
+conventions in order to keep code modular and maintainable.
+
+### 7.1. Prefer local state over global state
+
+Code which relies on local state is normally easier to understand and maintain
+than code which relies on global state.
+It is not possible to completely avoid global state, particularly in code that
+deals with the DOM. However, global state should be avoided when possible.
+Whenever possible, state should be stored locally in scoped variables or
+in class instances.
+
+### 7.2. Prefer immutable state over mutable state
+
+Where it will not substantially impact performance in a negative way,
+treat variables and objects as though they were immutable.
+
+### 7.3. Prefer pure functions over impure functions
+
+[Pure functions](https://www.sitepoint.com/functional-programming-pure-functions/)
+are those which accept inputs and produce their output without making any
+changes to the inputs and without producing any side-effects.
+In essence, a pure function is one which can be called at any time,
+any number of times, and the same inputs will always produce the same output.
 
 ``` ts
 // [Comment explaining the purpose of my pure function]
@@ -524,33 +1277,19 @@ function myPureFunction(value: number): number {
 }
 ```
 
-## Document the impure behavior of functions
+### 7.4. Functions should not modify their inputs
 
-In general, functions with side-effects should be avoided. However, this is often not possible, especially in code that is meant to manipulate DOM state.
-Functions which do have side-effects should have those side-effects clearly documented in code comments.
+Avoid writing functions that modify their inputs.
+Ensure that where such functions do exist, their modification of the input
+is clearly documented.
 
-``` ts
-// [Comment explaining the purpose of my function]
-// [Comment explaining the function's side-effects]
-function myDomRelatedFunction(): void {
-    doStuffWithSideEffects();
-}
-```
+### 7.5. Class getters should treat the instance as logically const
 
-In general, functions should not modify their inputs. When they must, it is important that this behavior be documented.
-
-``` ts
-// This function will modify the input object.
-// In particular, it assigns a new value to the object's
-// "myAttribute" attribute.
-function myFunction(myObject: Object): void {
-    myObject.myAttribute = "hello world";
-}
-```
-
-## Class getters should treat the instance as logically const
-
-In general, getters (i.e. methods preceded by the `get` keyword) should treat the instance `this` as [logically const](http://wiki.c2.com/?LogicalConst). Logical const means that the object may technically be modified, but any modification should not affect or be visible to code which uses only the object's intended and documented API.
+In general, getters (i.e. methods preceded by the `get` keyword) should treat
+the instance `this` as [logically const](http://wiki.c2.com/?LogicalConst).
+Logical const means that the object may technically be modified,
+but any modification that does take place should not affect or be visible to
+code which uses only the object's intended and documented API.
 
 ``` ts
 class MyClass {
@@ -574,133 +1313,20 @@ class MyClass {
 }
 ```
 
-## Explicitly document types
+### 7.6. Prefer template strings over concatenation
 
-Typing can be a pain when working with the DOM, but an effort should still be made to include correct types for variables, parameters, and retun types. In general, such types should always be included for internal code that does not deal with the DOM or other complex APIs not designed with static types in mind.
-
-## Prefer selective imports over default imports
-
-In general, selective imports should be used instead of default imports. (A default import is one without braces `{}`, e.g. `import DefaultSymbol from "location";`.)
-
-``` ts
-import {WADFile} from "@src/wad/file";
-```
-
-However, modules should still export a default symbol where there is an obvious default.
-
-``` ts
-// Actual export declared in "@src/wad/file"
-export default WADFile;
-```
-
-## Prefer absolute over relative imports
-
-In general, absolute import paths (those starting with an "at" sign `@`) should be preferred over relative paths (those starting with a dot `.`). Note that the meaning of these absolute paths are defined by macros in the TypeScript config file `tsconfig.json` and the webpack config file `webpack.config.js`.
-
-``` ts
-import {WADFile} from "@src/wad/file";
-```
-
-## Order imports logically, then alphabetically by filename
-
-In general, imports should first be ordered by logical group, and then alphabetically by filename. Each group should be separated by a single empty line. Groups should generally be ordered from most general to most specialized. Here is a guideline for how to order these groups:
-
-1. Native dependencies, such as Node.js imports.
-2. External dependencies, i.e. those listed in `package.json`.
-3. Jsdoom library dependencies, e.g. `@src/wad/` or `@src/lumps/`.
-4. Jsdoom UI or engine dependencies, e.g. `@web/`.
-
-``` ts
-import * as fs from "fs";
-import * as path from "path";
-
-import * as UPNG from "upng-js";
-
-import {WADFile} from "@src/wad/file";
-import {WADFileList} from "@src/wad/fileList";
-
-import {LumpTypeView} from "@web/lumpTypeView";
-```
-
-## Order of class member declarations
-
-In classes or objects, attributes should generally be defined in the source in the following order. In general, a single empty line should separate each group of listed declarations from the next group, and single empty line should separate each function or method declaration.
-
-1. Static class attributes.
-2. Instance attributes.
-3. Constructor(s)
-4. Static class functions
-5. Instance methods
-
-``` ts
-// [Comment explaining the purpose of my class]
-class MyClass {
-    // [Comment explaining the purpose of my constant]
-    static readonly MyStaticConstant: number = 0x8000;
-    
-    // [Comment explaining the purpose of my attribute]
-    myFirstAttribute: string;
-    // [Comment explaining the purpose of my attribute]
-    mySecondAttribute: string;
-    
-    constructor() {
-        this.myFirstAttribute = "hello";
-        this.mySecondAttribute = "world";
-    }
-    
-    // [Comment explaining the purpose of my function]
-    static myStaticFunction(): MyClass {
-        return new MyClass();
-    }
-    
-    // [Comment explaining the purpose of my method]
-    getTotalLength(): number {
-        return this.myFirstAttribute.length + this.mySecondAttribute.length;
-    }
-}
-```
-
-## Prefer rest arguments over referring to the arguments object
-
-Functions which accept a variable number of arguments should do so using a rest parameter `...` and not by accessing the `arguments` object. In general, functions should never access or manipulate the `arguments` object.
-
-``` ts
-// [Comment explaining the purpose of my function]
-function myVariadicFunction(...strings: string[]): void {
-    doStuffWith(strings);
-}
-```
-
-## Avoid the spread operator
-
-The spread operator `...` should be avoided except for where it replaces an expression such as `myFunction.apply(null, myArgumentList)` with one such as `myFunction(...myArgumentList)`.
-
-``` ts
-// Use `Array.concat` instead of the spread operator
-const myConcatenatedArray = (
-    myFirstArray.concat(mySecondArray)
-);
-```
-
-``` ts
-// Assign each key individually or, if the keys are numerous or not
-// necessarily known ahead of time, use `Object.assign` instead of
-// using the spread operator.
-const myComposedObject = {};
-Object.assign(myComposedObject, myFirstObject, mySecondObject);
-```
-
-## Prefer template strings over concatenation
-
-In general, template strings should be used instead of string concatenation or joining.
+Prefer using template strings over string concatenation or joining.
 
 ``` ts
 const myString: string = `${helloString} ${worldString}!`;
 ```
 
-## Prefer joining over repeated concatenation
+### 7.7. Prefer joining over repeated concatenation
 
-Strings that are incrementally assembled, e.g. in a loop, should be pushed to an array and combined at the end of the loop with a single `join` statement. Generally, such strings should not be assembled via repeated concatenation.
+Strings that are incrementally assembled, e.g. in a loop, should have their
+substrings pushed to an array and combined at the end of the loop with a
+single `join` statement.
+Avoid assembling strings via repeated concatenation.
 
 ``` ts
 // Create a comma-separated list representing the vertexes in an array.


### PR DESCRIPTION
Adds a code of conduct based on the [microsoft.github.io code of conduct](https://microsoft.github.io/codeofconduct/) at `conduct.md`.

Adds a code style guide amalgamated from several sources and my own beliefs about what makes code readable and maintainable at `style.md`.

@Talon1024 As the sole other contributor at the moment... I would appreciate it if you would read through these files and let me know if you have any comments.