### PR TITLE
Fix tall patch rendering

### DIFF
--- a/src/lumps/doom/picture.ts
+++ b/src/lumps/doom/picture.ts
@@ -225,6 +225,7 @@ export class WADPicture {
             };
             // Get ready to read the next post
             dataOffset = nextDataOffset;
+            lastPostOffset = postOffset;
         }
     }
 }


### PR DESCRIPTION
lastPostOffset was never set, so tall patch rendering didn't work properly.

To see this bug in action, take a look at VORPC0 in HF-v06.wad